### PR TITLE
Update env.yml

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -19,5 +19,5 @@ dependencies:
     - czifile
     - nd2reader
     - matplotlib
-    - ipykernel
+    - jupyter
     - .


### PR DESCRIPTION
Replace `ipykernel` by `jupyter` for users that will surely use the notebook via `jupyter notebook`.