### PR TITLE
Datatype fix for MPS 

### DIFF
--- a/src/microsplit_reproducibility/datasets/HT_H23B.py
+++ b/src/microsplit_reproducibility/datasets/HT_H23B.py
@@ -552,9 +552,10 @@ class MultiChDloaderRef:
 
     def normalize_target(self, target):
         mean_dict, std_dict = self.get_mean_std()
-        mean_ = mean_dict["target"]  # .squeeze(0)
-        std_ = std_dict["target"]  # .squeeze(0)
-        return (target - mean_) / std_
+        mean_ = mean_dict["target"].astype(np.float32)  # .squeeze(0)
+        std_ = std_dict["target"].astype(np.float32)  # .squeeze(0)
+        target = target.astype(np.float32)
+        return ((target - mean_) / std_).astype(np.float32)
 
     def get_grid_size(self):
         return self._grid_sz

--- a/src/microsplit_reproducibility/notebook_utils/HT_H23B.py
+++ b/src/microsplit_reproducibility/notebook_utils/HT_H23B.py
@@ -7,6 +7,7 @@ from microsplit_reproducibility.datasets import (
     SplittingDataset,
 )
 from microsplit_reproducibility.datasets.HT_H23B import get_train_val_data
+from microsplit_reproducibility.utils.utils import cast_model_floats
 
 import os
 from pathlib import Path
@@ -25,6 +26,7 @@ def load_pretrained_model(model: VAEModule, ckpt_path):
         raise ValueError(
             "Checkpoint path must start with 'checkpoints' or 'pretrained_checkpoints'."
         )
+    cast_model_floats(model)
     print(f"Loaded model from {ckpt_path}")
 
 

--- a/src/microsplit_reproducibility/notebook_utils/HT_H24.py
+++ b/src/microsplit_reproducibility/notebook_utils/HT_H24.py
@@ -7,6 +7,7 @@ from microsplit_reproducibility.datasets import (
     SplittingDataset,
 )
 from microsplit_reproducibility.datasets.HT_LIF24 import get_train_val_data
+from microsplit_reproducibility.utils.utils import cast_model_floats
 
 import os
 from pathlib import Path
@@ -25,6 +26,7 @@ def load_pretrained_model(model: VAEModule, ckpt_path):
         raise ValueError(
             "Checkpoint path must start with 'checkpoints' or 'pretrained_checkpoints'."
         )
+    cast_model_floats(model)
     print(f"Loaded model from {ckpt_path}")
 
 

--- a/src/microsplit_reproducibility/notebook_utils/HT_LIF24.py
+++ b/src/microsplit_reproducibility/notebook_utils/HT_LIF24.py
@@ -7,6 +7,7 @@ from microsplit_reproducibility.datasets import (
     SplittingDataset,
 )
 from microsplit_reproducibility.datasets.HT_LIF24 import get_train_val_data
+from microsplit_reproducibility.utils.utils import cast_model_floats
 
 import os
 from pathlib import Path
@@ -65,6 +66,7 @@ def load_pretrained_model(model: VAEModule, ckpt_path):
         raise ValueError(
             "Checkpoint path must start with 'checkpoints' or 'pretrained_checkpoints'."
         )
+    cast_model_floats(model)
     print(f"Loaded model from {ckpt_path}")
 
 

--- a/src/microsplit_reproducibility/notebook_utils/custom_dataset_2D.py
+++ b/src/microsplit_reproducibility/notebook_utils/custom_dataset_2D.py
@@ -4,6 +4,7 @@ from careamics.lvae_training.eval_utils import get_predictions, get_device
 from careamics.lightning import VAEModule
 from microsplit_reproducibility.datasets import create_train_val_datasets, SplittingDataset
 from microsplit_reproducibility.datasets.HT_LIF24 import get_train_val_data
+from microsplit_reproducibility.utils.utils import cast_model_floats
 
 import os
 from pathlib import Path
@@ -18,6 +19,7 @@ def load_pretrained_model(model: VAEModule, ckpt_path):
     device = get_device()
     ckpt_dict = torch.load(ckpt_path, map_location=device, weights_only=True)
     model.load_state_dict(ckpt_dict['state_dict'], strict=False)
+    cast_model_floats(model)
     print(f"Loaded model from {ckpt_path}")
 
 

--- a/src/microsplit_reproducibility/notebook_utils/custom_dataset_3D.py
+++ b/src/microsplit_reproducibility/notebook_utils/custom_dataset_3D.py
@@ -4,6 +4,7 @@ from careamics.lvae_training.eval_utils import get_predictions, get_device
 from careamics.lightning import VAEModule
 from microsplit_reproducibility.datasets import create_train_val_datasets, SplittingDataset
 from microsplit_reproducibility.datasets.HT_LIF24 import get_train_val_data
+from microsplit_reproducibility.utils.utils import cast_model_floats
 
 import os
 from pathlib import Path
@@ -16,6 +17,7 @@ def load_pretrained_model(model: VAEModule, ckpt_path):
     device = get_device()
     ckpt_dict = torch.load(ckpt_path, map_location=device, weights_only=True)
     model.load_state_dict(ckpt_dict['state_dict'], strict=False)
+    cast_model_floats(model)
     print(f"Loaded model from {ckpt_path}")
 
 

--- a/src/microsplit_reproducibility/utils/utils.py
+++ b/src/microsplit_reproducibility/utils/utils.py
@@ -14,6 +14,29 @@ def fix_seeds(seed: int = 0) -> None:
     torch.backends.cudnn.deterministic = True
 
 
+def cast_model_floats(
+    model: torch.nn.Module, dtype: torch.dtype = torch.float32
+) -> torch.nn.Module:
+    """
+    Cast every floating parameter and buffer to the requested dtype.
+    """
+    model.to("cpu")
+    model.to(dtype=dtype)
+
+    incompatible_tensors = []
+    for name, tensor in list(model.named_parameters()) + list(model.named_buffers()):
+        if torch.is_floating_point(tensor) and tensor.dtype != dtype:
+            incompatible_tensors.append(f"{name}:{tensor.dtype}")
+
+    if incompatible_tensors:
+        preview = ", ".join(incompatible_tensors[:5])
+        raise TypeError(
+            f"Model still contains floating tensors that are not {dtype}: {preview}"
+        )
+
+    return model
+
+
 def get_ignored_pixels(pred: torch.Tensor) -> int:
     """Get the number of ignored pixels in the predictions.
 


### PR DESCRIPTION
## Disclaimer

- [ ] I am an AI agent.
- [x] I have used AI and I thoroughly reviewed every line.
- [ ] I have not used AI extensively.

## Description

> [!NOTE]  
> **tldr**: Fix MPS `float64` inference failures by enforcing `float32` for model tensors and dataset normalization paths.

### Background - why do we need this PR?

Prediction notebooks were failing on Apple MPS with:
`Cannot convert a MPS Tensor to float64 dtype`.
Root cause was mixed precision from model/dataset paths producing `float64` tensors during inference.

### Overview - what changed?

Added a shared model dtype guard and applied float32 normalization.

### Implementation - how did you implement the changes?

- Introduced `cast_model_floats(...)` as a shared utility and invoked it after loading checkpoints in notebook helper modules.
- Ensured normalized targets in HT_H23B dataset are explicitly cast to `np.float32`.


### New features or files
- `cast_model_floats` added to `src/microsplit_reproducibility/utils/utils.py`.

### Modified features or files
- `src/microsplit_reproducibility/notebook_utils/HT_H23B.py`
- `src/microsplit_reproducibility/notebook_utils/HT_H24.py`
- `src/microsplit_reproducibility/notebook_utils/HT_LIF24.py`
- `src/microsplit_reproducibility/notebook_utils/custom_dataset_2D.py`
- `src/microsplit_reproducibility/notebook_utils/custom_dataset_3D.py`
- `src/microsplit_reproducibility/datasets/HT_H23B.py`


## How has this been tested?

- Manual predict notebook validation:
  - Recreate dataset/model after restart.
  - Confirm dataloader batch dtypes are `torch.float32`.
  - Re-run prediction cell that previously failed on MPS on HT_H23B and HT_LIF24 

## Related Issues

- Resolves #22 
