### PR TITLE
MPS float64 fix in train

### DIFF
--- a/examples/2D/HT_H23B/01_train.ipynb
+++ b/examples/2D/HT_H23B/01_train.ipynb
@@ -1,1729 +1,511 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1:** Training a <nobr>Micro$\\mathbb{S}$plit</nobr> Model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Introduction - what does this notebook do?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> Despite network training arguably being the most important step, the execution of this notebook is optional. If you do not run this notebook, in Step 2 (prediction) we offer you to use pretrained model checkpoints. Like in any respected cooking show: \"we have already prepared someting before the show\"... 😉\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Below, we will train a <nobr>Micro$\\mathbb{S}$plit</nobr> network for removing unwanted imaging artifacts from our HT_H23B dataset. \n",
-    "\n",
-    "More specifically, we imaged the post-mitotic neuronal marker CTIP2 in sliced hPSC-derived forebrain\n",
-    "organoids using a secondary antibody conjugated to a 555 dye. The resulting image data not only had\n",
-    "CTIP2+ nuclear staining (wanted signal), but also puncta that accumulated because of non-specific signal\n",
-    "(i.e. undesired artifacts).\n",
-    "Ideally, we could use MicroSplit to unmix the labeled nuclei (desired image content) and the undesired\n",
-    "puncta (i.e. imaging artifacts). However, for this we would need training targets that contain only nuclei\n",
-    "and others that contain only puncta, a requirement that this experimental setup does not\n",
-    "permit. That's why we manually selected image regions that show\n",
-    "only the artifacts (puncta) or only the desired structures (the signal, in this example, nuclei). The selected\n",
-    "image regions are then combined and used to train a MicroSplit\n",
-    "network. Since crops without puncta or crops that show only puncta are of limited size with respect to full\n",
-    "microscopy images (the smallest crops we collected were 100 → 100 pixels), lateral contextualization could not be used and was therefore disabled during training. In total, we have manually\n",
-    "cropped 82 content regions and 48 puncta regions from the data. This took an analyst about eight hours of focused work.\n",
-    "\n",
-    "Here, we assume that images of each single structure exist, but we no longer assume that all structures have\n",
-    "been imaged in each sample. As before, here we also generate superimposed inputs by summing images showing different fluorescent structures. However, unlike before, summed-up input images no longer originate\n",
-    "from the same sample, and any spatial correlations that might exist between these cellular structures\n",
-    "are lost\n",
-    "\n",
-    "This dataset contains 2 labeled structures:\n",
-    "1. Puncta\n",
-    "2. Foreground\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Background: what is <nobr>Micro$\\mathbb{S}$plit</nobr> training all about?\n",
-    "Training is done in a supervised way. For every input patch, we have the two corresponding target patches using which we train our MicroSplit. \n",
-    "Besides the primary input patch, we also feed LC inputs to MicroSplit. We introduced LC inputs in [μSplit: efficient image decomposition for microscopy data](https://openaccess.thecvf.com/content/ICCV2023/papers/Ashesh_uSplit_Image_Decomposition_for_Fluorescence_Microscopy_ICCV_2023_paper.pdf), which enabled the network to understand the global spatial context around the input patch.\n",
-    "\n",
-    "To enable unsupervised denoising, we integrated the KL loss formulation and Noise models from our previous work [denoiSplit: a method for joint microscopy image splitting and unsupervised denoising](https://eccv.ecva.net/virtual/2024/poster/2538). \n",
-    "\n",
-    "The loss function for MicroSplit is a weighted average of denoiSplit loss and μSplit loss. For both denoiSplit and μSplit, their loss expression have two terms: KL divergence loss and likelihood loss. For more details, please refer to the respective papers."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Let's do it, let's train a <nobr>Micro$\\mathbb{S}$plit</nobr> Model!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**You are new to Jupyter notebooks?** Don't worry, if you take the time to read all our explanations, we will guide you through them and you will understand a lot. Still, you will likely end up less frustrated, if you do not even start with the ambition to interpret the purpose of every line of code.\n",
-    "Let's start with a nice example, the imports to enable the remainder of this notebook. Ignore it (unless you know what you are doing) and just click **⇧*Shift* + ⏎*Enter*** to execute this (and all other) code cells. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# importing all the things we need further down\n",
-    "import platform\n",
-    "\n",
-    "import pooch\n",
-    "import matplotlib.pyplot as plt\n",
-    "from pytorch_lightning import Trainer\n",
-    "from torch.utils.data import DataLoader\n",
-    "from careamics.lightning import VAEModule\n",
-    "\n",
-    "from microsplit_reproducibility.configs.factory import (\n",
-    "    create_algorithm_config,\n",
-    "    get_likelihood_config,\n",
-    "    get_loss_config,\n",
-    "    get_model_config,\n",
-    "    get_optimizer_config,\n",
-    "    get_training_config,\n",
-    "    get_lr_scheduler_config,\n",
-    ")\n",
-    "from microsplit_reproducibility.utils.callbacks import get_callbacks\n",
-    "from microsplit_reproducibility.utils.io import load_checkpoint, load_checkpoint_path\n",
-    "from microsplit_reproducibility.datasets import create_train_val_datasets\n",
-    "from microsplit_reproducibility.utils.utils import (\n",
-    "    plot_training_metrics,\n",
-    "    plot_training_outputs,\n",
-    ")\n",
-    "\n",
-    "# Dataset specific imports...\n",
-    "from microsplit_reproducibility.configs.parameters.HT_H23B import get_microsplit_parameters\n",
-    "from microsplit_reproducibility.configs.data.HT_H23B import get_data_configs\n",
-    "from microsplit_reproducibility.datasets.HT_H23B import get_train_val_data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.1:** Data Preparation"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Download the data\n",
-    "Depending on your internet connection, this will take a while...\n",
-    "\n",
-    "Note that appropriate noise models will only be downloaded if they were not created by executing the notebook `00_noisemodels.ipynb`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "DATA = pooch.create(\n",
-    "    path=\"./data/\",\n",
-    "    base_url=\"https://download.fht.org/jug/msplit/ht_h23b/data/\",\n",
-    "    registry={\"ht_h23b.zip\": None},\n",
-    ")\n",
-    "\n",
-    "NOISE_MODELS = pooch.create(\n",
-    "    path=\"./noise_models/\",\n",
-    "    base_url=\"https://download.fht.org/jug/msplit/ht_h23b/noise_models/\",\n",
-    "    registry={\n",
-    "        \"ht_h23b_nm_raw_data.npz\": None,\n",
-    "    },\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that the following notebook will download all you need. In case you see no messages announcing any downloads, you already have this data in the notebook folder."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "---------\n"
-     ]
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1:** Training a <nobr>Micro$\\mathbb{S}$plit</nobr> Model"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Introduction - what does this notebook do?"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b>Note:</b> Despite network training arguably being the most important step, the execution of this notebook is optional. If you do not run this notebook, in Step 2 (prediction) we offer you to use pretrained model checkpoints. Like in any respected cooking show: \"we have already prepared someting before the show\"... 😉\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Below, we will train a <nobr>Micro$\\mathbb{S}$plit</nobr> network for removing unwanted imaging artifacts from our HT_H23B dataset. \n",
+        "\n",
+        "More specifically, we imaged the post-mitotic neuronal marker CTIP2 in sliced hPSC-derived forebrain\n",
+        "organoids using a secondary antibody conjugated to a 555 dye. The resulting image data not only had\n",
+        "CTIP2+ nuclear staining (wanted signal), but also puncta that accumulated because of non-specific signal\n",
+        "(i.e. undesired artifacts).\n",
+        "Ideally, we could use MicroSplit to unmix the labeled nuclei (desired image content) and the undesired\n",
+        "puncta (i.e. imaging artifacts). However, for this we would need training targets that contain only nuclei\n",
+        "and others that contain only puncta, a requirement that this experimental setup does not\n",
+        "permit. That's why we manually selected image regions that show\n",
+        "only the artifacts (puncta) or only the desired structures (the signal, in this example, nuclei). The selected\n",
+        "image regions are then combined and used to train a MicroSplit\n",
+        "network. Since crops without puncta or crops that show only puncta are of limited size with respect to full\n",
+        "microscopy images (the smallest crops we collected were 100 → 100 pixels), lateral contextualization could not be used and was therefore disabled during training. In total, we have manually\n",
+        "cropped 82 content regions and 48 puncta regions from the data. This took an analyst about eight hours of focused work.\n",
+        "\n",
+        "Here, we assume that images of each single structure exist, but we no longer assume that all structures have\n",
+        "been imaged in each sample. As before, here we also generate superimposed inputs by summing images showing different fluorescent structures. However, unlike before, summed-up input images no longer originate\n",
+        "from the same sample, and any spatial correlations that might exist between these cellular structures\n",
+        "are lost\n",
+        "\n",
+        "This dataset contains 2 labeled structures:\n",
+        "1. Puncta\n",
+        "2. Foreground\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Background: what is <nobr>Micro$\\mathbb{S}$plit</nobr> training all about?\n",
+        "Training is done in a supervised way. For every input patch, we have the two corresponding target patches using which we train our MicroSplit. \n",
+        "Besides the primary input patch, we also feed LC inputs to MicroSplit. We introduced LC inputs in [μSplit: efficient image decomposition for microscopy data](https://openaccess.thecvf.com/content/ICCV2023/papers/Ashesh_uSplit_Image_Decomposition_for_Fluorescence_Microscopy_ICCV_2023_paper.pdf), which enabled the network to understand the global spatial context around the input patch.\n",
+        "\n",
+        "To enable unsupervised denoising, we integrated the KL loss formulation and Noise models from our previous work [denoiSplit: a method for joint microscopy image splitting and unsupervised denoising](https://eccv.ecva.net/virtual/2024/poster/2538). \n",
+        "\n",
+        "The loss function for MicroSplit is a weighted average of denoiSplit loss and μSplit loss. For both denoiSplit and μSplit, their loss expression have two terms: KL divergence loss and likelihood loss. For more details, please refer to the respective papers."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Let's do it, let's train a <nobr>Micro$\\mathbb{S}$plit</nobr> Model!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**You are new to Jupyter notebooks?** Don't worry, if you take the time to read all our explanations, we will guide you through them and you will understand a lot. Still, you will likely end up less frustrated, if you do not even start with the ambition to interpret the purpose of every line of code.\n",
+        "Let's start with a nice example, the imports to enable the remainder of this notebook. Ignore it (unless you know what you are doing) and just click **⇧*Shift* + ⏎*Enter*** to execute this (and all other) code cells. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# importing all the things we need further down\n",
+        "import platform\n",
+        "\n",
+        "import pooch\n",
+        "import matplotlib.pyplot as plt\n",
+        "from pytorch_lightning import Trainer\n",
+        "from torch.utils.data import DataLoader\n",
+        "from careamics.lightning import VAEModule\n",
+        "\n",
+        "from microsplit_reproducibility.configs.factory import (\n",
+        "    create_algorithm_config,\n",
+        "    get_likelihood_config,\n",
+        "    get_loss_config,\n",
+        "    get_model_config,\n",
+        "    get_optimizer_config,\n",
+        "    get_training_config,\n",
+        "    get_lr_scheduler_config,\n",
+        ")\n",
+        "from microsplit_reproducibility.utils.callbacks import get_callbacks\n",
+        "from microsplit_reproducibility.utils.io import load_checkpoint, load_checkpoint_path\n",
+        "from microsplit_reproducibility.datasets import create_train_val_datasets\n",
+        "from microsplit_reproducibility.utils.utils import (\n",
+        "    plot_training_metrics,\n",
+        "    plot_training_outputs,\n",
+        ")\n",
+        "\n",
+        "# Dataset specific imports...\n",
+        "from microsplit_reproducibility.configs.parameters.HT_H23B import get_microsplit_parameters\n",
+        "from microsplit_reproducibility.configs.data.HT_H23B import get_data_configs\n",
+        "from microsplit_reproducibility.datasets.HT_H23B import get_train_val_data"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.1:** Data Preparation"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Download the data\n",
+        "Depending on your internet connection, this will take a while...\n",
+        "\n",
+        "Note that appropriate noise models will only be downloaded if they were not created by executing the notebook `00_noisemodels.ipynb`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "DATA = pooch.create(\n",
+        "    path=\"./data/\",\n",
+        "    base_url=\"https://download.fht.org/jug/msplit/ht_h23b/data/\",\n",
+        "    registry={\"ht_h23b.zip\": None},\n",
+        ")\n",
+        "\n",
+        "NOISE_MODELS = pooch.create(\n",
+        "    path=\"./noise_models/\",\n",
+        "    base_url=\"https://download.fht.org/jug/msplit/ht_h23b/noise_models/\",\n",
+        "    registry={\n",
+        "        \"ht_h23b_nm_raw_data.npz\": None,\n",
+        "    },\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Note that the following notebook will download all you need. In case you see no messages announcing any downloads, you already have this data in the notebook folder."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "for fname in NOISE_MODELS.registry:\n",
+        "    NOISE_MODELS.fetch(fname, progressbar=True)\n",
+        "print('---------')\n",
+        "for fname in DATA.registry:\n",
+        "    DATA.fetch(fname, processor=pooch.Unzip(), progressbar=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Next, we load the image data to be processed\n",
+        "\n",
+        "Note that depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 64, but you can reduce it to 32 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> below.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "***Note:*** if you want to use the noise model you trained in the previous notebook, change the `nm_fname` in the cell below to `user_trained_noise_model.npz`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "nm_fname = \"ht_h23b_nm_raw_data.npz\"\n",
+        "# nm_fname = \"user_trained_noise_model.npz\"\n",
+        "\n",
+        "# setting up train, validation, and test data configs\n",
+        "train_data_config, val_data_config, test_data_config = get_data_configs()\n",
+        "# setting up MicroSplit parametrization\n",
+        "experiment_params = get_microsplit_parameters(nm_path=NOISE_MODELS.path / nm_fname, batch_size=64)\n",
+        "\n",
+        "# start the download of required files\n",
+        "train_dset, val_dset, _, data_stats = create_train_val_datasets(\n",
+        "    datapath=DATA.path / \"ht_h23b.zip.unzip/ht_h23b\",\n",
+        "    train_config=train_data_config,\n",
+        "    val_config=val_data_config,\n",
+        "    test_config=val_data_config,\n",
+        "    load_data_func=get_train_val_data,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Configure `num_workers`\n",
+        "In Windows and MacOS, setting `num_workers > 0` for dataloaders would cause out-of-memory issue and might crash the system."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def get_num_workers():\n",
+        "    \"\"\"Utility function to set num_workers based on OS.\"\"\"\n",
+        "    if platform.system() == \"Windows\" or platform.system() == \"Darwin\":\n",
+        "        return 0\n",
+        "    else:\n",
+        "        return 3  # or any other number suitable for your system\n",
+        "    \n",
+        "    experiment_params[\"num_workers\"] = get_num_workers()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "***Optional:*** inspect data configurations and <nobr>Micro$\\mathbb{S}$plit</nobr> config"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "do_show_configs = True\n",
+        "\n",
+        "if do_show_configs:\n",
+        "    print('FYI: train_data_config')\n",
+        "    print('----------------------')\n",
+        "    for cfg in train_data_config:\n",
+        "        print(cfg)\n",
+        "\n",
+        "    print('\\nFYI: experiment_params')\n",
+        "    print('----------------------')\n",
+        "    print(experiment_params)\n",
+        "else:\n",
+        "    print('You opted out of having all params printed... swiftly moving on... ;)')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Final step: create Dataloaders for network training"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "train_dloader = DataLoader(\n",
+        "    train_dset,\n",
+        "    batch_size=experiment_params[\"batch_size\"],\n",
+        "    num_workers=experiment_params[\"num_workers\"],\n",
+        "    shuffle=True,\n",
+        ")\n",
+        "val_dloader = DataLoader(\n",
+        "    val_dset,\n",
+        "    batch_size=experiment_params[\"batch_size\"],\n",
+        "    num_workers=experiment_params[\"num_workers\"],\n",
+        "    shuffle=False,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.2:** Prepare <nobr>Micro$\\mathbb{S}$plit</nobr> Training\n",
+        "Next, we create all the configs for the upcoming network training run. These lines are not very intuitive and if you don't intend to dive really deep into CAREamics and the internals of <nobr>Micro$\\mathbb{S}$plit</nobr>, you might just execute these cells and move on."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# making our data_stas known to the experiment we prepare\n",
+        "experiment_params[\"data_stats\"] = data_stats\n",
+        "\n",
+        "# setting up training losses and model config (using default parameters)\n",
+        "loss_config = get_loss_config(**experiment_params)\n",
+        "model_config = get_model_config(**experiment_params)\n",
+        "gaussian_lik_config, noise_model_config, nm_lik_config = get_likelihood_config(\n",
+        "    **experiment_params\n",
+        ")\n",
+        "training_config = get_training_config(**experiment_params)\n",
+        "\n",
+        "# setting up learning rate scheduler and optimizer (using default parameters)\n",
+        "lr_scheduler_config = get_lr_scheduler_config(**experiment_params)\n",
+        "optimizer_config = get_optimizer_config(**experiment_params)\n",
+        "\n",
+        "# finally, assemble the full set of experiment configurations...\n",
+        "experiment_config = create_algorithm_config(\n",
+        "    algorithm=experiment_params[\"algorithm\"],\n",
+        "    loss_config=loss_config,\n",
+        "    model_config=model_config,\n",
+        "    gaussian_lik_config=gaussian_lik_config,\n",
+        "    nm_config=noise_model_config,\n",
+        "    nm_lik_config=nm_lik_config,\n",
+        "    lr_scheduler_config=lr_scheduler_config,\n",
+        "    optimizer_config=optimizer_config,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Wanna trade speed for model quality?\n",
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b>Note:</b> If you simply want to go over this notebook quickly and you don't care about training a competitive model, set <i>`reduce_training_epochs=True`</i> in the cell below. \n",
+        "\n",
+        "Note that if <i> reduce_training_epochs </i> is set to <i>False </i>, the default number of epochs is 400. However, early stopping will be invoked when the loss is no longer decreasing, so the actual number of epochs trained will most likely be less than 400.\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "reduce_training_epochs = True\n",
+        "\n",
+        "# if True, train for only 10 epochs (quick'n'dirty testing mode)\n",
+        "if reduce_training_epochs:\n",
+        "    training_config.num_epochs = 10\n",
+        "\n",
+        "print(f'Will train for {training_config.num_epochs} epochs!')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Initialize the <nobr>Micro$\\mathbb{S}$plit</nobr> model to be trained.."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "model = VAEModule(algorithm_config=experiment_config)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Show some training data for a final check!\n",
+        "***Tip:*** we show you a few samples of the prepared training data. In case you don't like what you see, execute the cell again and other randomly chosen patches will be shown!"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "_, ax = plt.subplots(figsize=(15, 10), ncols=3)\n",
+        "inp, tar = train_dset[0]\n",
+        "ax[0].imshow(inp.squeeze())\n",
+        "ax[0].set_title(\"Input\")\n",
+        "ax[1].imshow(tar[0])\n",
+        "ax[1].set_title(\"Target channel 1\")\n",
+        "ax[2].imshow(tar[1])\n",
+        "ax[2].set_title(\"Target channel 2\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.3:** Train the prepared model!\n",
+        "***Note:*** if this takes too long, there were two places above where we gave you options to *(i)* reduce the amount of training data, and *(ii)* chose to train for fewer epochs. Revisit your choices if you want to!\n",
+        "\n",
+        "***Note:*** Depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> above.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### If you're not using MPS as your accelerator, ingore next cell"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# If you encounter float \"Cannot convert a MPS Tensor to float64\" error, run this cell\n",
+        "from microsplit_reproducibility.utils.utils import cast_model_floats\n",
+        "cast_model_floats(model)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# create a CAREamics 'Trainer'\n",
+        "trainer = Trainer(\n",
+        "    max_epochs=training_config.num_epochs,\n",
+        "    # NOTE: if you are on a mac swap the accelerator to \"mps\"\n",
+        "    # accelerator=“mps”,\n",
+        "    accelerator=\"gpu\",\n",
+        "    enable_progress_bar=True,\n",
+        "    callbacks=get_callbacks(f\"./checkpoints/\"),\n",
+        "    precision=training_config.precision,\n",
+        "    gradient_clip_val=training_config.gradient_clip_val,\n",
+        "    gradient_clip_algorithm=training_config.gradient_clip_algorithm,\n",
+        ")\n",
+        "# start the training - yay!\n",
+        "trainer.fit(\n",
+        "    model=model,\n",
+        "    train_dataloaders=train_dloader,\n",
+        "    val_dataloaders=val_dloader,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Show training loss curves...\n",
+        "Below, we plot for each epoch of your training run the *(i)* training reconstruction loss, *(ii)* training KL divergence loss, *(iii)* validation reconstruction loss, and *(iv)* validation PSNR. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pandas import read_csv\n",
+        "from microsplit_reproducibility.notebook_utils.HT_LIF24 import find_recent_metrics, plot_metrics\n",
+        "df = read_csv(find_recent_metrics())\n",
+        "plot_metrics(df)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### You are done here! 👍 Congratulations! 🎉"
+      ]
     }
-   ],
-   "source": [
-    "for fname in NOISE_MODELS.registry:\n",
-    "    NOISE_MODELS.fetch(fname, progressbar=True)\n",
-    "print('---------')\n",
-    "for fname in DATA.registry:\n",
-    "    DATA.fetch(fname, processor=pooch.Unzip(), progressbar=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Next, we load the image data to be processed\n",
-    "\n",
-    "Note that depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 64, but you can reduce it to 32 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> below.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "***Note:*** if you want to use the noise model you trained in the previous notebook, change the `nm_fname` in the cell below to `user_trained_noise_model.npz`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n"
-     ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "microsplit-reproducibility",
+      "language": "python",
+      "name": "python3"
     },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Train: 38 Val: 5 Test: 5\n",
-      "Train: 61 Val: 17 Test: 4\n",
-      "Padding is not used with this alignement style\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Train: 38 Val: 5 Test: 5\n",
-      "Train: 61 Val: 17 Test: 4\n",
-      "Padding is not used with this alignement style\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Train: 38 Val: 5 Test: 5\n",
-      "Train: 61 Val: 17 Test: 4\n",
-      "Padding is not used with this alignement style\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/src/microsplit_reproducibility/datasets/HT_H23B.py:21: FutureWarning: The plugin infrastructure in `skimage.io` and the parameter `plugin` are deprecated since version 0.25 and will be removed in 0.27 (or later). To avoid this warning, please do not use the parameter `plugin`. Instead, use `imageio` or other I/O packages directly. See also `imread`.\n",
-      "  data = imread(path, plugin=\"tifffile\")\n"
-     ]
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.14"
     }
-   ],
-   "source": [
-    "nm_fname = \"ht_h23b_nm_raw_data.npz\"\n",
-    "# nm_fname = \"user_trained_noise_model.npz\"\n",
-    "\n",
-    "# setting up train, validation, and test data configs\n",
-    "train_data_config, val_data_config, test_data_config = get_data_configs()\n",
-    "# setting up MicroSplit parametrization\n",
-    "experiment_params = get_microsplit_parameters(nm_path=NOISE_MODELS.path / nm_fname, batch_size=64)\n",
-    "\n",
-    "# start the download of required files\n",
-    "train_dset, val_dset, _, data_stats = create_train_val_datasets(\n",
-    "    datapath=DATA.path / \"ht_h23b.zip.unzip/ht_h23b\",\n",
-    "    train_config=train_data_config,\n",
-    "    val_config=val_data_config,\n",
-    "    test_config=val_data_config,\n",
-    "    load_data_func=get_train_val_data,\n",
-    ")"
-   ]
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Configure `num_workers`\n",
-    "In Windows and MacOS, setting `num_workers > 0` for dataloaders would cause out-of-memory issue and might crash the system."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_num_workers():\n",
-    "    \"\"\"Utility function to set num_workers based on OS.\"\"\"\n",
-    "    if platform.system() == \"Windows\" or platform.system() == \"Darwin\":\n",
-    "        return 0\n",
-    "    else:\n",
-    "        return 3  # or any other number suitable for your system\n",
-    "    \n",
-    "    experiment_params[\"num_workers\"] = get_num_workers()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "***Optional:*** inspect data configurations and <nobr>Micro$\\mathbb{S}$plit</nobr> config"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "FYI: train_data_config\n",
-      "----------------------\n",
-      "('data_type', <DataType.HTH23BData: 13>)\n",
-      "('depth3D', 1)\n",
-      "('datasplit_type', <DataSplitType.Train: 1>)\n",
-      "('num_channels', 2)\n",
-      "('ch1_fname', None)\n",
-      "('ch2_fname', None)\n",
-      "('ch_input_fname', None)\n",
-      "('input_is_sum', True)\n",
-      "('input_idx', None)\n",
-      "('target_idx_list', None)\n",
-      "('start_alpha', None)\n",
-      "('end_alpha', None)\n",
-      "('image_size', (64, 64))\n",
-      "('grid_size', 32)\n",
-      "('empty_patch_replacement_enabled', False)\n",
-      "('empty_patch_replacement_channel_idx', None)\n",
-      "('empty_patch_replacement_probab', None)\n",
-      "('empty_patch_max_val_threshold', None)\n",
-      "('uncorrelated_channels', True)\n",
-      "('uncorrelated_channel_probab', 1.0)\n",
-      "('poisson_noise_factor', -1.0)\n",
-      "('synthetic_gaussian_scale', 6675.0)\n",
-      "('input_has_dependant_noise', True)\n",
-      "('enable_gaussian_noise', False)\n",
-      "('allow_generation', False)\n",
-      "('training_validtarget_fraction', None)\n",
-      "('deterministic_grid', None)\n",
-      "('enable_rotation_aug', False)\n",
-      "('max_val', None)\n",
-      "('overlapping_padding_kwargs', {'mode': 'reflect'})\n",
-      "('print_vars', False)\n",
-      "('normalized_input', True)\n",
-      "('use_one_mu_std', True)\n",
-      "('train_aug_rotate', True)\n",
-      "('enable_random_cropping', True)\n",
-      "('multiscale_lowres_count', 1)\n",
-      "('tiling_mode', <TilingMode.ShiftBoundary: 2>)\n",
-      "('target_separate_normalization', True)\n",
-      "('mode_3D', False)\n",
-      "('trainig_datausage_fraction', 1.0)\n",
-      "('validtarget_random_fraction', None)\n",
-      "('validation_datausage_fraction', 1.0)\n",
-      "('random_flip_z_3D', False)\n",
-      "('padding_kwargs', {'mode': 'reflect'})\n",
-      "('channel_list', ['puncta', 'foreground'])\n",
-      "('background_values', [0, 0])\n",
-      "('test_frame_idx', 8)\n",
-      "\n",
-      "FYI: experiment_params\n",
-      "----------------------\n",
-      "{'algorithm': 'denoisplit', 'loss_type': 'denoisplit', 'img_size': (64, 64), 'encoder_conv_strides': [2, 2], 'decoder_conv_strides': [2, 2], 'target_channels': 2, 'multiscale_count': 1, 'predict_logvar': None, 'nm_paths': ['noise_models/ht_h23b_nm_raw_data.npz', 'noise_models/ht_h23b_nm_raw_data.npz'], 'kl_type': 'kl', 'batch_size': 64, 'lr': 0.001, 'lr_scheduler_patience': 30, 'earlystop_patience': 200, 'num_epochs': 400, 'num_workers': 0, 'mmse_count': 50, 'grid_size': 32}\n"
-     ]
-    }
-   ],
-   "source": [
-    "do_show_configs = True\n",
-    "\n",
-    "if do_show_configs:\n",
-    "    print('FYI: train_data_config')\n",
-    "    print('----------------------')\n",
-    "    for cfg in train_data_config:\n",
-    "        print(cfg)\n",
-    "\n",
-    "    print('\\nFYI: experiment_params')\n",
-    "    print('----------------------')\n",
-    "    print(experiment_params)\n",
-    "else:\n",
-    "    print('You opted out of having all params printed... swiftly moving on... ;)')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Final step: create Dataloaders for network training"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "train_dloader = DataLoader(\n",
-    "    train_dset,\n",
-    "    batch_size=experiment_params[\"batch_size\"],\n",
-    "    num_workers=experiment_params[\"num_workers\"],\n",
-    "    shuffle=True,\n",
-    ")\n",
-    "val_dloader = DataLoader(\n",
-    "    val_dset,\n",
-    "    batch_size=experiment_params[\"batch_size\"],\n",
-    "    num_workers=experiment_params[\"num_workers\"],\n",
-    "    shuffle=False,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.2:** Prepare <nobr>Micro$\\mathbb{S}$plit</nobr> Training\n",
-    "Next, we create all the configs for the upcoming network training run. These lines are not very intuitive and if you don't intend to dive really deep into CAREamics and the internals of <nobr>Micro$\\mathbb{S}$plit</nobr>, you might just execute these cells and move on."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/.venv/lib/python3.10/site-packages/careamics/utils/serializers.py:62: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
-      "  return torch.tensor(lst)\n"
-     ]
-    }
-   ],
-   "source": [
-    "# making our data_stas known to the experiment we prepare\n",
-    "experiment_params[\"data_stats\"] = data_stats\n",
-    "\n",
-    "# setting up training losses and model config (using default parameters)\n",
-    "loss_config = get_loss_config(**experiment_params)\n",
-    "model_config = get_model_config(**experiment_params)\n",
-    "gaussian_lik_config, noise_model_config, nm_lik_config = get_likelihood_config(\n",
-    "    **experiment_params\n",
-    ")\n",
-    "training_config = get_training_config(**experiment_params)\n",
-    "\n",
-    "# setting up learning rate scheduler and optimizer (using default parameters)\n",
-    "lr_scheduler_config = get_lr_scheduler_config(**experiment_params)\n",
-    "optimizer_config = get_optimizer_config(**experiment_params)\n",
-    "\n",
-    "# finally, assemble the full set of experiment configurations...\n",
-    "experiment_config = create_algorithm_config(\n",
-    "    algorithm=experiment_params[\"algorithm\"],\n",
-    "    loss_config=loss_config,\n",
-    "    model_config=model_config,\n",
-    "    gaussian_lik_config=gaussian_lik_config,\n",
-    "    nm_config=noise_model_config,\n",
-    "    nm_lik_config=nm_lik_config,\n",
-    "    lr_scheduler_config=lr_scheduler_config,\n",
-    "    optimizer_config=optimizer_config,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Wanna trade speed for model quality?\n",
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> If you simply want to go over this notebook quickly and you don't care about training a competitive model, set <i>`reduce_training_epochs=True`</i> in the cell below. \n",
-    "\n",
-    "Note that if <i> reduce_training_epochs </i> is set to <i>False </i>, the default number of epochs is 400. However, early stopping will be invoked when the loss is no longer decreasing, so the actual number of epochs trained will most likely be less than 400.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Will train for 10 epochs!\n"
-     ]
-    }
-   ],
-   "source": [
-    "reduce_training_epochs = True\n",
-    "\n",
-    "# if True, train for only 10 epochs (quick'n'dirty testing mode)\n",
-    "if reduce_training_epochs:\n",
-    "    training_config.num_epochs = 10\n",
-    "\n",
-    "print(f'Will train for {training_config.num_epochs} epochs!')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Initialize the <nobr>Micro$\\mathbb{S}$plit</nobr> model to be trained.."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[GaussianMixtureNoiseModel] min_sigma: 0.125\n",
-      "[GaussianMixtureNoiseModel] min_sigma: 0.125\n",
-      "[MultiChannelNoiseModel] Nmodels count:2\n"
-     ]
-    }
-   ],
-   "source": [
-    "model = VAEModule(algorithm_config=experiment_config)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Show some training data for a final check!\n",
-    "***Tip:*** we show you a few samples of the prepared training data. In case you don't like what you see, execute the cell again and other randomly chosen patches will be shown!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Text(0.5, 1.0, 'Target channel 2')"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABLkAAAGXCAYAAABfpYIsAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAA80tJREFUeJzs/Xt83GWd9oFfmckcMpPJTM5p0lN6DFAqUKAU0CKCFQ+IsOthDx7XVRf8KT7uwefZXcR1H93HA7orwv7UB38eEFdXXUUFERQ5VmjBFqQptEmbJs1hksxkMpM5ZGZ+f/SxbfK57nUCrXTa6/169Y9+et/f+3z4fptcV025XC5DCCGEEEIIIYQQQogqxvNiV0AIIYQQQgghhBBCiBeKPnIJIYQQQgghhBBCiKpHH7mEEEIIIYQQQgghRNWjj1xCCCGEEEIIIYQQourRRy4hhBBCCCGEEEIIUfXoI5cQQgghhBBCCCGEqHr0kUsIIYQQQgghhBBCVD36yCWEEEIIIYQQQgghqh595BJCCCGEEEIIIYQQVY8+cgkhhBBCnGC8/e1vR319/YtdjWPG29/+dixfvvzFroYQQoij0FkjTkb0kUucUnz1q19FTU0NHn/88Re7KshkMvjoRz+KX/7yly92VYQQ4oSgpqamoj8n2r758MMP46Mf/SgSicSLXZWq59e//jX+6q/+Chs2bIDP50NNTc2LXSUhxEmGzppTm1KphK9+9au48sorsWTJEoTDYaxbtw4f//jHkc1mX+zqiWNA7YtdASFOVTKZDG688UYAwCWXXPLiVkYIIU4Avv71r8/5+9e+9jXcc889Jn7aaaf9Iav1e3n44Ydx44034u1vfztisdiLXZ2q5ic/+Qm+/OUvY/369VixYgV27979YldJCHGSobPm1CaTyeAd73gHLrjgArz3ve9FW1sbHnnkEdxwww249957cd999+k/WKocfeQSQgghxAnBn/3Zn835+6OPPop77rnHxJ8P5XIZ2WwWdXV1L/hZ4vjxvve9D3/7t3+Luro6XHfddfrIJYQ45uisObXx+/146KGHcOGFFx6Ovfvd78by5csPf+i67LLLXsQaiheKfl1RnNL87vfQBwcHcdVVV6G+vh6tra348Ic/jGKxeDhdf38/ampq8OlPfxo33XQTli1bhrq6OmzevBlPPfXUnGdecskl9Cezjv4d8f7+frS2tgIAbrzxxsM/Fv3Rj370eDVVCCFOCm677TZceumlaGtrQyAQwOmnn45bbrnFpFu+fDle+9rX4u6778a5556Luro6/Pu//zsAYN++fbjyyisRDofR1taG66+/HnfffTf99ZStW7fiVa96FaLRKEKhEDZv3oyHHnro8L9/9KMfxV//9V8DALq7uw/v5/39/f9tO7Zu3YpXv/rVaGxsRDgcxvr16/H5z3/epPt95xMAfPrTn8aFF16I5uZm1NXVYcOGDfjud79rnlVTU4PrrrsOP/jBD7Bu3ToEAgGcccYZuOuuu+ak++hHP4qamho899xzh39iIBqN4h3veAcymYx57je+8Q1s2LABdXV1aGpqwpvf/GYMDAz8t+130d7erpdDIcSLjs6ak/es8fv9cz5w/Y43vOENAIBnnnlmwc8UJxb6SS5xylMsFrFlyxZs3LgRn/70p/Hzn/8cn/nMZ7By5Uq8733vm5P2a1/7GlKpFK699lpks1l8/vOfx6WXXoqdO3eivb294jJbW1txyy234H3vex/e8IY34OqrrwYArF+//pi2TQghTjZuueUWnHHGGbjyyitRW1uLH/3oR/irv/orlEolXHvttXPS9vb24i1veQve85734N3vfjfWrl2LdDqNSy+9FAcPHsQHPvABdHR04Pbbb8cvfvELU9Z9992HK664Ahs2bMANN9wAj8dz+MXngQcewPnnn4+rr74au3fvxre+9S3cdNNNaGlpAYDD/5HBuOeee/Da174WixYtOlyHZ555BnfeeSc+8IEPHE5X6fn0+c9/HldeeSX+9E//FPl8HnfccQf++I//GHfeeSde85rXzCn7wQcfxPe+9z381V/9FSKRCP71X/8V11xzDfbv34/m5uY5ad/4xjeiu7sbn/jEJ7B9+3Z8+ctfRltbG/7lX/7lcJp//ud/xj/8wz/gjW98I/7iL/4CY2Nj+Ld/+ze87GUvwxNPPKFfqRFCVCU6a069s2Z4eBgADvetqGLKQpxC3HbbbWUA5ccee6xcLpfLb3vb28oAyh/72MfmpDv77LPLGzZsOPz3vr6+MoByXV1d+cCBA4fjW7duLQMoX3/99YdjmzdvLm/evNmU/ba3va28bNmyw38fGxsrAyjfcMMNx6ZxQghxknHttdeW519VMpmMSbdly5byihUr5sSWLVtWBlC+66675sQ/85nPlAGUf/CDHxyOzczMlHt6esoAyr/4xS/K5XK5XCqVyqtXry5v2bKlXCqV5pTf3d1dvvzyyw/HPvWpT5UBlPv6+n5vm2ZnZ8vd3d3lZcuWlScnJ+f829HlVHo+/a5OR5PP58vr1q0rX3rppXPiAMp+v7/83HPPHY795je/KQMo/9u//dvh2A033FAGUH7nO985J/8b3vCGcnNz8+G/9/f3l71eb/mf//mf56TbuXNnuba2dk58/hlYCWz8hRDiWKOz5tQ+a37HZZddVm5oaDD9JaoP/bqiEADe+973zvn7S1/6Uuzdu9eku+qqq9DV1XX47+effz42btyIn/zkJ8e9jkIIITDnV9mSySTi8Tg2b96MvXv3IplMzknb3d2NLVu2zInddddd6OrqwpVXXnk4FgwG8e53v3tOuieffBLPPvss/uRP/gTj4+OIx+OIx+NIp9N4xStegV/96lcolUoLrv8TTzyBvr4+fPCDHzT/88yEbis5n47uk8nJSSSTSbz0pS/F9u3bzfMuu+wyrFy58vDf169fj4aGBnrmsbLHx8cxNTUFAPje976HUqmEN77xjYf7Jx6Po6OjA6tXr6Y/sSCEENWAzppT66z53//7f+PnP/85PvnJT+onkE8C9OuK4pQnGAyaH/VtbGzE5OSkSbt69WoTW7NmDf7jP/7juNVPCCHEER566CHccMMNeOSRR4xmRzKZRDQaPfz37u5uk3/fvn1YuXKlueSvWrVqzt+fffZZAMDb3vY2Z12SySQaGxsXVP89e/YAANatW/d701Z6Pt155534+Mc/jieffBK5XO5wnL3ILF261MRcZ978tL9r6+TkJBoaGvDss8+iXC7TsxEAfD6fo2VCCHFio7Pm1Dlrvv3tb+Pv//7v8a53vctI1YjqRB+5xCmP1+s9ps+rqalBuVw28fnijUIIIRbGnj178IpXvAI9PT347Gc/iyVLlsDv9+MnP/kJbrrpJvO/3S9EwPx3z/rUpz6Fs846i6apr69/3s+vhErOpwceeABXXnklXvayl+GLX/wiFi1aBJ/Ph9tuuw233357xc9k59bvS1sqlVBTU4Of/vSnNO3x7h8hhDge6KyxnKxnzT333IO3vvWteM1rXoNbb731eT9HnFjoI5cQC+B3/9tyNLt37z7smggc+t8H9qO4+/btm/N39r8eQggh3PzoRz9CLpfDD3/4wzn/87uQX1VYtmwZfvvb36JcLs/Zh5977rk56X73axYNDQ2/10p8Ifv575771FNPHROL8v/8z/9EMBjE3XffjUAgcDh+2223veBn/z5WrlyJcrmM7u5urFmz5riXJ4QQfwh01lhOxrNm69ateMMb3oBzzz0X//Ef/4HaWn0aOVmQJpcQC+AHP/gBBgcHD//917/+NbZu3YorrrjicGzlypXYtWsXxsbGDsd+85vfzLEBBoBQKAQASCQSx7fSQghxkvC7/8E9+n+Ck8nkgi7ZW7ZsweDgIH74wx8ejmWzWXzpS1+ak27Dhg1YuXIlPv3pT2N6eto85+g9PhwOA6hsPz/nnHPQ3d2Nz33ucyY9+x/u34fX60VNTc2cnxbu7+/HD37wgwU/a6FcffXV8Hq9uPHGG03dy+UyxsfHj3sdhBDiWKOzxnKynTXPPPMMXvOa12D58uW48847X9BP44kTD32uFGIBrFq1ChdffDHe9773IZfL4XOf+xyam5vxN3/zN4fTvPOd78RnP/tZbNmyBe9617swOjqKW2+9FWecccZhAUXg0I82n3766fj2t7+NNWvWoKmpCevWravod+eFEOJU5JWvfCX8fj9e97rX4T3veQ+mp6fxpS99CW1tbTh48GBFz3jPe96DL3zhC3jLW96CD3zgA1i0aBG++c1vIhgMAjjyP+Uejwdf/vKXccUVV+CMM87AO97xDnR1dWFwcBC/+MUv0NDQgB/96EcADr2kAMD/+l//C29+85vh8/nwute97vALydF4PB7ccssteN3rXoezzjoL73jHO7Bo0SLs2rULTz/9NO6+++4F9clrXvMafPazn8WrXvUq/Mmf/AlGR0dx8803Y9WqVdixY8eCnrVQVq5ciY9//OP4yEc+gv7+flx11VWIRCLo6+vD97//ffzlX/4lPvzhDy/omfv27cPXv/51AMDjjz8OAPj4xz8O4NBPRvz5n//5sW2EEELMQ2eN5WQ6a1KpFLZs2YLJyUn89V//NX784x+b8jZt2nSsmyH+gOgjlxAL4K1vfSs8Hg8+97nPYXR0FOeffz6+8IUvYNGiRYfTnHbaafja176Gf/zHf8SHPvQhnH766fj617+O22+/Hb/85S/nPO/LX/4y3v/+9+P6669HPp/HDTfcoI9cQgjhYO3atfjud7+Lv//7v8eHP/xhdHR04H3vex9aW1vxzne+s6Jn1NfX47777sP73/9+fP7zn0d9fT3e+ta34sILL8Q111xz+AUEAC655BI88sgj+Kd/+id84QtfwPT0NDo6OrBx40a85z3vOZzuvPPOwz/90z/h1ltvxV133YVSqYS+vj764gEc+h/+X/ziF7jxxhvxmc98BqVSCStXrjSuW5Vw6aWX4itf+Qo++clP4oMf/CC6u7vxL//yL+jv7z/uLx4A8Hd/93dYs2YNbrrpJtx4440AgCVLluCVr3zlHFexSunr68M//MM/zIn97u+bN2/WRy4hxHFHZ43lZDprxsfHMTAwcPi583nb296mj1xVTk35+fy8ohCnGP39/eju7sanPvWpBf+vtBBCiBOfz33uc7j++utx4MABdHV1vdjVEUIIcRKis0aI4480uYQQQghxSjEzMzPn79lsFv/+7/+O1atX66VDCCHEMUFnjRAvDvp1RSGEEEKcUlx99dVYunQpzjrrLCSTSXzjG9/Arl278M1vfvPFrpoQQoiTBJ01Qrw46COXEEIIIU4ptmzZgi9/+cv45je/iWKxiNNPPx133HEH3vSmN73YVRNCCHGSoLNGiBcHaXIJIYQQQgghhBBCiKpHmlxCCCGEEEIIIYQQouo54X5dsVQqYWhoCJFIBDU1NS92dYQQouopl8tIpVLo7OyEx6P/2wB01gghxLFGZ81cdM4IIcSxpeJzpnyc+MIXvlBetmxZORAIlM8///zy1q1bK8o3MDBQBqA/+qM/+qM/x/jPwMDA8dryXxSe7zlTLuus0R/90R/9OV5/TqazRueM/uiP/ujPiffn950zx+Unub797W/jQx/6EG699VZs3LgRn/vc57Blyxb09vaira3tv80biUQAAJ3/+3/CEwwejtcN8qp6CjaWbS+ZWOtpYzT/8GCTidX1+yoqBwCKdTZWP1A2Me+sjQFAoc7+z05qhU3nH+f/A5Tpsm0NTNivmsUQLz+y18ZY+QBQk7ex1ieLJubJ87LSnXYMWb/WD5GCABR9tl2pZfaZkX2zNP/wxTbtbNDWtfG3vK+nF9vY8h9NmVhNnpf/3IdDJtb5bVun0NZnaX5G4lU9JpZp5l+1Cw021vyUrWvkySGaf9+bl5pYbI8d/0CCt39kQ8DEwgdt/5fs8gMA5KJ2XHwZPtfCB229Sj6bP7HSS/M37bJt8KXtM11MLfNXlM43w+s/3WHHMJC0aQNJu/4BIBedm7+Yz+Lpb/3T4f31ZOCFnDPAkbPmtNveD2/oyNzMb7VnAgDMdLC9zo6Tb1mK5i89a/u+drry/9nPNdnxr99n85ccUy/XbPOz8jNL+fqtydu0/gm7fvJNla8Tlh8Ayn5b17qDL6ytAXKGFu2WBADw5ip7JusTAMgtIw8gRJ7iFQi/YsTEiv/x++f07xi7wI5B9Gl71rRu53N1psNebCbX2vxsTQDucZ1P++P8rN//WrL/Ddvy2fkBAMnVNuYlRdXv4/WaONu2y9UmNgdYWZnVfE74D9pJzJ45W8/bytYwS+vaa9h6bXjWtrVunJ81k2vmjlUpl0XfTR87ac6aY3XOdF//j/AEjrzTFGK8P0ODdu6nl9kx8rVmKm0CZg+GTczj2LvYnbymQO5eaV4Wyz/1Ejv3G37D977UKtvWmllbvqv+UXJ9Hj+Xn2meGTvP6/vJmZ52vL+FbR0KtqsR7eNjzfLnYjZWP1jZ2gP4u543w/uqfpCkJe9vrvffsVfbcY08EjQx/zTvv8CkHevkCscLAGF6ue2Xlicqzo5MGzlnErauRcc9Y6bV9mvdmM0/vYznDw2RO42j+aFR29Z8PcvPx5rl9xRsXf0pvlbiZ9r1Wut4/2LMhmy98rHK8/sTc/MX81k8+++//5w5Lh+5PvvZz+Ld73433vGOdwAAbr31Vvz4xz/G//2//xd/93d/NydtLpdDLndkoaRShy5dnmAQnroji8UbcHzkIu/znqAdzNow31CPLuNIWeQjl+un4chjveSC7q3hg1nyk83bVgnegONAqrNt9QZsZcvkYw4AeMniZeUDvA9qfeTFz+Fl4PWTj1ykWbW1vLNryEcu9sxan+NAC5Ly68hYkTEBAC/pl1ryNlTj5ZdhT8g+oNZH6l9T2QcSAPD62Pzl/Vcic5X1Va2HrxVvgNXfjn9tLe9/b8A+l62VGscmz9aA6+Mxqxfb/L0BPla0X2orf3n3+isbQ1f92Riyvqr18cvPrN+xhk6iX5dYyDkDuM8abygw5yMXm+cA4Kkjex3ZFL0hx40wSNYqeXlw4SF7ONurahwfbmh+Ur6nzvGRy1vZ+mH95MK1/kqB49BWdoa6PnJV+EyPYz15yH9e0XLIngg47it+x8FMy7djQM/KWj5Xa+m5ws5PPtaucbXl833KU0fWFSmf7YkAv8Ow+wu7/xwqn6z1oONcJ3OALBXnnPAEbSXYM0uuOxxZwyyta6/hc8W21XXWuO4bJ8tZc6zOGU8gOOdsKZL3FID3Jx2jEM/PKJGzx8Mu3wA8ZJqztF5+TPB3MjL3XXsfayv7yOaqP32ncZxpnrJtLL17kY8BAFAiZwq/Z/OxYu9/7JxayNpj73reoquvSFqwGMdDPlx4yTnl2qfZPZ29f7tg7/quPZ1R6T0bjmfSdxKS3/VOzfI733/8rK0kv+P9lc0hDxnrBb2/Od5fGGXSVnancuH6BvL7zplj/gvz+Xwe27Ztw2WXXXakEI8Hl112GR555BGT/hOf+ASi0ejhP0uWLDnWVRJCCHESsdBzBtBZI4QQonJ0zgghRPVyzD9yxeNxFItFtLe3z4m3t7djeHjYpP/IRz6CZDJ5+M/AwMCxrpIQQoiTiIWeM4DOGiGEEJWjc0YIIaqXF91dMRAIIEB+DK6m4EHNUT/K7lQPIz9t37CH/J7zrnabEIC3x/643Mxa+yto3V/nxe+9xv4g52yY/AqH4/fH81Fbfst2m3bsYv5rBaG99mcbC+SZsWdodvo7xbPkVyABoOUZm3Z0g20r0z5xwXROSj7+s6HTVhIKvilb1tBmPlmY/kYhzL7z8h+hbNxl4wcui5kY+51sAAg8Rcb1LJtu5lWn0/zhAVvXzl9ZTRVv3mp/AcDoIpuf/QrfyKtIRwMID9l2Db/Bio+0/tjxO0CEWVLV0Biff8GEjWVj/Ds9m5ehgzZd54MzNP/kWvLzxa32mWz9AEDDPtuGkVfaNRzbyuc600BgscnV/AfJi/N+DbeYpclOKVxnTeJgw9xfjSd7kosg03lKEfE7AD6i05MlZflSjv2zy87VFKx2EtMDAoBCxM7J0CD5dY1UZb9qBgC5FvJrXTm+Jlm92K8lAlwDI9tS2TMB3tYi+RVeV36A6Ec0k1+tcPRVsM/Os2DcpmM6iQAw8XCHiWUvIr9GEOC/LtjYPG1i+f5mE5v+GBfWmXjY6lz4iXxXdBdvf+piqxfk22U3++GNfP+L7bCxlW/ZbWJ7vrWG5mdnOJsTqW4+V2M77B0i2cP72kf+r5j9ylLsMX4uZrpYXcm9KOA4F/vsGJxxuRUm2vY0F1tt6LVtZWut5Pi1RLOGnGvq1MB1zhRipTm/olibrvyeHBi1Y+zr41o0mXPsOeHrsuu89Vv8njh8gR3n2TDRA2qk2VH22bnL9sPpjfzuFei1Z9psmLzT9PLypxeTfiW/6gUATVvt3B8/h+ifJfjcrxu1MaYzlCYaqwCQPMNe6qJP23e64U00O4Kk/CIZK3/CcU8k22+h3tY1MsD3vpaf2nEd22DbHz7A2z/ZY8eqbRvT6XKcs6NEk4z8umCuka81pp/GdNJcmmSV0ryT33My7baswCRPO7bBxsIHbP7QCJ/rbA4y/eyJnsrf34rkVyNDI7z+qW4yLwZt/qk1fK7lW+e2qzRT2aAc85/kamlpgdfrxcjIXOHUkZERdHTYi5sQQgixEHTOCCGEOJ7onBFCiOrlmH/k8vv92LBhA+69997DsVKphHvvvRebNjk+RwshhBAVonNGCCHE8UTnjBBCVC/H5dcVP/ShD+Ftb3sbzj33XJx//vn43Oc+h3Q6fdidRAghhHgh6JwRQghxPNE5I4QQ1clx+cj1pje9CWNjY/jHf/xHDA8P46yzzsJdd91lxBuFEEKI54POGSGEEMcTnTNCCFGdHDfh+euuuw7XXXfd8Xq8EEKIUxydM0IIIY4nOmeEEKL6eNHdFV00/6YG3qOU+2daebqZDuskUBq3UmO11uwHANC6nTgxRK3lxN5ruOJ/TYE5Fth0LsfBEnG3YI5t9b3WcQMApldYxyVWp4kzaXbaL7UzvK4TZ9q+CpC+LvGqIpCw+SODdvw8Be7OMNNqpytzMizW8frnYjbGHAOnl/L8Xke/zIc5Brpg5Tc+y9vvKdixnjyt3sTYOAF8DmZa7fhNreT5mbtjx/ftBK5N87XSnLZjHd5nXcA88STN3//ny0xsvovg72BOmLmobf/0Eu4kEkzYuiaXW4eXxmd5W1NdNm1wjy0rkOROKFPLiGsJde3kc3L+WBdzlTs5nWp4p73wzB4ZL5fjXnDcjmmaOPE27OBzqkjCxRZbWHCc56/x2/WfJY5r4SHuRJQnTo7M2c3l4lYmrkV+0icuQsRJxwVz4mGOc8E+/swQbL2ie227Jnq4LCkbV+TsM119BeK6yBz3susdF5NB4prJnBwd7o7poSYTC5ImTd/NxbNz3XZfyxHHPTYnAKAmXplDU7abVApAIWLPlZ2/Wm1iQUcxzKG0YQc567r5/GHzLxDnfZ3ttOuSuTOytQYAwThxaCXtynTS7LSuTw4s5okJU+vtGIR7bQVYnQAgvXxu+0szxAVUoPHpue801AUQ3B2xfqvdD9KO+cTSBifsPpV46xTNX/tEzMRKxMjMdc/3VOgaGdpu6wkA02TvKYftnIo7nLW99TZtwMfn5Pg5dp0yJ8tcG7/n1aZtWubEx/ofAECcFMPDNm3O0Vbm5FhHHJN93ETX6To4n9QSvvfNtJEzebRyd8JFD5M7TRNxMSflAIA/Qd5piGMhc+cEgMBkZe6EzEUQALzEnZDR9BixVgaQfFObiU1387nSda+NDV9AzinSJhepbhvreJTPdeZwSef6JK9/mMxLRk2B1z/21Ny1WszX4kAFzzvmwvNCCCGEEEIIIYQQQvyh0UcuIYQQQgghhBBCCFH16COXEEIIIYQQQgghhKh69JFLCCGEEEIIIYQQQlQ9J6zw/HzS67hAaWyrFSidXmbF2Mq1DjHyvI3nYjZWd5B3VQ3RM2Ri1IH3HqT5k3d0kfJtOiawD3Ax1Np1VlDSf08Dzc/ItvC+8k2RviJixrUZnn/8HCJo57P5feO8rzsesZ093Wnbv/w/ucjf5FlWjNdHxNBzMV4+E5Rv2Gfzs2cCQG2GiBE7xDsZmdbKhP88s7z/mUh//SAR6UxygcDJHpu/5Smbf/RsrlDL2jrdGTWxzCIbA4ASETmedQjPM0H90Jgdl+lO/p2/8VnbrvqhysToXfiIzmtgkos8dozYgR0+3/brsv/icz23KDLn77OzfP8UQO10DbxHiV3WnTtO06V32v3DG7fnTz5iQofSOgTt58ME1gHA97jdwxcRMfWhK/hYB/vs/GF18jnEzJlIejFFBNId7WTC2/lOnpjVNddi10qmyyE+vDZlYpPn2nSFPN/r/X1cFHk+kT4eT6wlIv1EDN23i7uUuObAfJp3OMrvsTEPmRZZIiYP8HtFkGw1qYu5cL6X9F8pYNvkMmmo3zJsYvFt7SaWbeH9xOYVE7P32WlyiC4r/l1Xb2MAUCL7QoFct/LNfK8HMUlglCNcPLtErvE+0v8xx1wt+m1+Ni8a+nhfz89fzFXNa8UflEK4BqXAkT3AJYbNBNlTDjFqBnt/YT/PkN3tuGc12rJqiZj8orPsGgWAxM8WmRgTDi+szdL89aT9sVeOVlTOISq/VNeEbYzdM5mYO8DHkN1zU0v4ORXbY/uapW3ZyfeOQtiOS956UWGmrXIxcmbQ4qp/mCh/pxfbPgmN8LImTrOdVSBj4k/w/ExQPzJg+4qJpgNAYJII50/Y/CPn8jkVIML3jF3vb6bxukEW43WdIGd6mOQvkPEHuKGBb9rWP91e+c8+sbFymRT4pm1fJ9badB2P8LI8hbn1ny1UtifqJ7mEEEIIIYQQQgghRNWjj1xCCCGEEEIIIYQQourRRy4hhBBCCCGEEEIIUfXoI5cQQgghhBBCCCGEqHpOWIVIX6aE2qOExWqHrWgoADTuJgKjYStmGu3nwn2Lr3/WxJ7+vlV4m17CRT+bliRMbO3rh0zsvp2n0fyhViv8Vku0XIMruEJqetgqv+VILH0Or7+XiIz7k1xML5Agwt8hIly3pHKR/JYdNu3kal7+6AabP0T0/Acv52q6vjQT+rTfebvu4WLeA6+2zy36bF1D03yuMeH4YIKJfPL+8/ltWQXS/807uKApEzmf7qp8C6B9vdmuy9BBXn77I0kTG9lkxU/r9/PyfRn73FyUz5X0JdMmFviJXReFBl5XT97GM8vtXOnYysWIkyuCND6f8TO4oOXinydMLDxk+3q+wPzh8rvnpi3mKxeuPdXJP8xFQj3kCHIKVxN+9L7/Y2Kvu+VvTMwlOs7i8ZfY+R/u5WLeRVL/YJyIgV7K5zQTSWdi4rFdNDvGzrNzkAnMA0DTLps2/hK7/ordvK6eHZUZrZSImD0AFIlwOavr+Ln8XA0OMTFv21cu4fpCxI4rE453mRwsZF4y2LgyQ5rwY1w4v36QmHSsIOLXDuF43N1hQj4yVbwOP43QoE3MxNSdAv+DVvy63MfbCmKowJ7b0MvPWtcYzmch6zo8RM6vV/FJ4SGGFtlONq95/ee3tUTMhMSh+6e3cKRvZtu46Ub0UdvPM2127bj2jlyjjaXJHC0v5sLvZy8dMLHLmp8xsa/svYjmZyLzxbDdD1w/YZHfaOfpUDxmYi/94500/68eOcPx5MpgIvsug6hCzLarebttWcZ6ZgAAEisr+zkTlxj4LBGeZ2LqLuH6oZfZ/Gyfrj/gMHhqZ+XbdP7phdw/KxfJZ8LnEz32PYsJ1APA1Aobi2+0MT8x7QKAyIBtFys/9hQfP9Yv42fy9jOjh+nv23NyciPfV8I/tZN4erEtyzVXmKB8rpHcaQZ4X4UPWjMt/7Stk6fA889fA8V8ZWtHP8klhBBCCCGEEEIIIaoefeQSQgghhBBCCCGEEFWPPnIJIYQQQgghhBBCiKpHH7mEEEIIIYQQQgghRNWjj1xCCCGEEEIIIYQQouo5Yd0V42d74Ake+QbHHC8AYPh86zhTiBInkcvGaP69/9+1Jub/I+uu5+1tovnDX46Z2AObrDtX83M0O3I2O3LNtv6ugfJm7HfK8ABxMbrQus0BwOLuhInt7XNYgcA6IcyGbV09s5W7Y0yuto4NzF0SABqftU4UgUnrAjRwOXfiDFiDGGRaiROKw52RuUuGRm35mXZuxRLts64XBy+087fF4Y7oI66LhZDtvxHiDgIAdcO2Xh2/tvZUk2t4/3msOQZ1x0wut3UCgH2vi5lY/X7b1okzefvX/MseEyt3tdK0+2O2LH/auoa07KDZMbzJrrgVX7P2kvv+eBHNz/q16LdzreTjK5u5TrL+Ty3mYzXftXO2IHdFF/mmIjx1R+ZG2c/nn3/czutst13TnYuIvRCAP/6nvzax9EV2njTs4C5qzLGOuSv6pmh2eMljmePa67t/S/Pf2Wc3lkKEuAOt5/93xtx1uYsbcJA4+XlaiBsYccEDgEIPOUQcaRl+4mTqJ+Z03J8MyHbbcfXG7TMT9voBACgF7F4V3cX31UrJEIe1YNxxVqcqO8PT5/HDOtVNHK6J62aROAYfym/bz+ZPppM7QXlydg76KmwTAHQ+aJ+ba+D9nyRrgI0Vc3cEuBNjrNemG7+Iu2bFHmNOkratxV5u45gn903qDupYq/PTFnOV9/OpRHI14DnKdDm0m+/zoxvI/Z+8/0xu5Nai/kG7zwTXWGfrQoHP56fvWWNi29tWmpgvwff5EnknaNhNnNlifD/OdtmLTvRpe3d9KsrvXm+65GET+9av+aU4OMjc3Uid2vj9qb7Ptmt6sU0XSNDsCE5Udi+b7OFrqm2b3aeSK5gLHh/rpp3ECZPcf5iLIgDE9tj6j26waV3v7wzmmFhy3MnYc0Mjlde/YS8J7rV7X66R5x/dYNdA3ahNl1jHx7nrXhtr5qahGE/Y+e4lfdXyAH8nGN1Ayr/fTvbEKv7+6psm58QEcWFu4vtCtsnud8y1lDlWAoB3/vHHj0ODfpJLCCGEEEIIIYQQQlQ9+sglhBBCCCGEEEIIIaoefeQSQgghhBBCCCGEEFWPPnIJIYQQQgghhBBCiKrnhBWeDw8A3qP00xI9XIys7LPx1q1WZG8y3UHzz1xshdcCT1jh+MCMQ/h+k403E+Hw4ZdzgdS6/VzkbT6R73LR0Ow5NjYbsrGWKBee99xo24q38jp4Z2ys7XErRjq1nE+rDNGJZCLzTOAdAML7beKa3+y2+c8mCnsAxjbauvqm7FypO8jHeqbVxtv+q98+s4coTwLY80dWeC88YNNlY1wkMn6O7ZfOB+z87/4hF4iNr7Plj55tY7407//6QfvcyTVEzH4rmSgAJtcGTSyYsOuidTv/9j61eYWJMeMAgIuHsrSt2/i6yLTWm9jk+daQoezYQfddYfulbtiWn2vhfc32EGY8kGnlc6V2floJzzvx5D3weI6MTTHCFS0LEbv+mejzSLfDuIOIjNek7ATK860eBy+2c6Jph61TYi2fU8HxysSo7378Ap6f6Bz7Unb+RS8Zpvnxf9tMKB7g89dDxKu9Q+Rgc5CFFTUuBewaKEf4XhnaZcc11W371dvA54q3z5bPhM+9XDsa6fPsP2S67DNDg/ysSq+tTPjeNddq1lv3gvKOBhMrxbl4NhN+Z8Lr1CAAQGiHHWsm0L7oQd7+DBFedwm/M8Ze8sKuxmyuNDtMTsbOs/My1U3OtRxfKwU7LE5BfgYT9A9a7yWUHGv1+QoCn2qEhmrgDRyZl2liBAEAszG7JzGBdCYwDwDFbmuHkX/aGtkw0WcAABGOD4zasS+s5fe88qStV6rbzvFIH7+7ldfZ+qe6bfmlMb55/eRnF5tY4GLiGgKgNGbXeXSvbX/Jx+s602bThsmeHBng67Hks2nr/+NREyu+cxPNf/CP7GIr5m1da0f5XKlN29iiH1g19vHLuml+JjLvT9hYiRdPjdfqDxAjjt18ro1stOfElH1NoAZZAFAk9UotIaYlpJ9cMDOB4KP8nMoSQXuXSL7ZZ8Hfc1xE+mws3WHnPxP+B4DpjXZdhrbbOwlbE67yAdvWdAdfa6Zf87yc+egnuYQQQgghhBBCCCFE1aOPXEIIIYQQQgghhBCi6tFHLiGEEEIIIYQQQghR9egjlxBCCCGEEEIIIYSoek5Y4fmirwbwHxEl8yd5Ou+MbcLUSitI1rCHi5Q1XjRuYmPjVjh4NsSF6/xJ+50wNGIV4rxJrvLIxNyZIOQYEZgHuPD40EttusK3uBjy6DlEDDfJ28pE7g78mRXJbPoZn1a+KVIWEY/Lxbjw3r7XWjHwwCYrMl+0WngAgJqQFX8sZez4BRI8PxMfZGLoE6dxgdbYLttWJnzoLTiE+/bauuaJSGhyORcDZvMqPGTzR/dagUEASK6wwvG5Zpvfk+NizoWwHVfPIBFz9vH2p7psvy66dRtNm7zmbBOb7CHzr4+LZHvWr6Lx+fisPjMAoGaWzSvbrrYnuEpvbcrGp1Y5FCEJ011z12Axf8Ju9S863jzgOXq4iEA3ABQjdv9gYtZM4B0AsmSt+FJEoLuTr59wPxEJJdq7bE8FXCLnRPiTiJYDQLDP7itMDNx7Nzd5qYc9V5gYu4v0ctsvNXmePzRk94pss+3rMGkTAGSIKDSra2GQHzbetVboOB23IrkNvXxdBonwOjsrQlfy/Su102F+MI9cCxdEDhCReQYTmAeA9sds/013kf2XtBPg+2p6ua3rRA/vP9auph22rsxMAgBS3Tb/4nv5upo4zdahdK5tQL6P92mkj98XLDwdE5mP7iJC4Y4hZfuCK614/hTCQIlvN3OI7LYXtWkyH+sd82bNZutmtH1ypYl503ztFsN2n27eadfJSBdfe54CER4nd++ZNr72Gn9o7zmjF9i1F9rNOzN5NjHdKPC6sh6MX2Hzt/yUlzV+ZmXn1/AFvK9Lftsuf8+FFaUDgPKorVctOROZGDwA5BptbPTV9p3GdadgIvv0PWOYv1PmYmRPrrfPHHopPyeKZ9tztvYJeynyOIyXJnoq23ubn+Z3onHY/s82VX6nYXT82lHWGRVsHgCad3IzrX1X2H5ZiKB+4Cl718k1kneabXyueMh7bWpJpWefNQQoOu4eptyKSxBCCCGEEEIIIYQQ4gRFH7mEEEIIIYQQQgghRNWjj1xCCCGEEEIIIYQQourRRy4hhBBCCCGEEEIIUfXoI5cQQgghhBBCCCGEqHpOWMut2HMF1PqOKO/Pdwv7Hb6MdU0YvtjGcuM8/4pIwsSmD1p3qEIDd0woESe41GLmzsUdB2Y6bF2ZO0XLdlf5Nh4esN8uvQ53CZbfM+sqy8aKxDUy83puORf8ibXsySyq3ImCuTMyF6C2x4kNJIAp4prGHCMnXsndBRsetO6C8fW2r9u2cXe0TCtzkrDzYnw975O6gzaWOM3GfA4n0oZ9dg4UQras4Y3cMazQYOvaSBwjZyPcnY45tHjztk7OtZ62+fv/F7cdbdlhnxsYJ9/0W4m9DIC2X1rXsuHL7b4QGeTuZFniGuPL8D2AMb7eOok29tp5OXiJw0p0HsXcC3N8OZmp3wd4j5qy2RbeV8UUcTfsyZhYw0/5mGSbbSxE3InyxC0NAAoRtn+Q/M08P/OSKkTsOvEP8fXrt0ZGtPzoXr7/jb2EuUPyNcGcDJmTYtnhOlWpO9/UWpqdOlkyd0wX+T7rZOQnRqpT67mTUg2Za8yFL76NuyiymcLmmsuxL9njmkNzKUf4WCdXWCcoNibMxRAAYhcmTKztO00mlu7i9WJ9le606Vzuksw1cuR8XlZo0MYyvXb8I4O8r3INtq7j62268JBjX/LbujJ3UI/jDGCupW0P2TqNXlTZvsLuxOKQk5l3Tlfz8agl9xzmhJhaw++5a+pHTeyJgnWLrht1zIfFNp5pt+XXOhz7ZmPEBbdAnG0P0OzINhFnatskZNscjveD9vyaJS7kLorTdu9NX8PfaTxPR02sQEywXe6G+ZiNMSfFRQ/zvSOxiryUEZjjJAA0brV9FX+pPag6f1pZOQAw02brn9/IbfyCD9p9Mk32LubiCAA+kp+Vn1zBz7m6UZs2vdimyzbz9rOy2rbZeZltdDiZkqtW/2t5WWy9sPzjZ9p3BwBo2Wn3b+ZuyN6JAcBD3t9CIyQdcVEEgEKYfGsgz8w1utbK3LSlbGVrWj/JJYQQQgghhBBCCCGqHn3kEkIIIYQQQgghhBBVjz5yCSGEEEIIIYQQQoiqRx+5hBBCCCGEEEIIIUTVc8IKz4+cXwtv8Ej1PAWH8BwRI68hwmk5h2jsr5/tNrEYEUNLR3n+hj22fCbQ7k/y74k1RE8wkCDldzrE4Mfsc7MXTptY41etECwAhEZsZzEhUxfRflJ+jKjBg4vMt+ywHcAF2oFgwgr6JZfbtMOb+LTueMSWFRi3Yt5Tq7hwHxPOq99PRA6Xu8q3ys37XmvLWnkHV44fO9eKXPqes+lmWml2BCat8OB0p52s0X4uMBuYtP1XqLf9n2vk7W/cbQUtAwdtn3gWE4VuAMGErVf9YOWCoiWfrWv/NS007bIfJWxZQ7b80Q18rrK5Ftpnx9VVfr5nxsTaHrbindE9fF3nonPnapHsaeIQ08sAz1GeEsVuKyYPAN4+KyhfzNnxT/Twcvzddq4nWvj4MZgYe4aI1AeH+PorBewciO6y9Wei1YfKJyYr3WRPXsHLD8ZtzE/aBAB5qyeLxffa8pmYPcCF02M7iJg8X34VC9czgXqAC8I27SImG3E+/h6iE7wQMfHF99v9o+89Nn/kwZCjfGKcQcYq6xCe95L6u/qaUb7LngELyc/6L0hiOdf4k7aGh/i6YGPNcM1VNi/CQ7b/Cxdx8evOr9sxHLrYrut8Mx8r/zg/w+bj2lfmUyYGEQKYXl6CJ3hkrCN9/J7NhZfJ2s/wcfv2Ly80sdZtNt1kD5/P/kki/D7JBLod+cfsPGHvREzg+1Ba+9zgGnt3qv+RvQ+74XPSP23LGt1g61+zO0bze4jIvI9orLP2A1z8nwl/73s9z995r907ZprsM71+LtKfWGfj0SfsmTThuNOwurI2RR/l50y63fa/yxCB4SPjN9Nm00X3OgyiiCA8E3hnfQoADXttzJuzfep17IleYkbj2heYSDt7J504k6/Lpp32ueyZJT+v60ybjXd/2zpC7LuaDACA0EX2Alj3NWsm42beO02FZlr6SS4hhBBCCCGEEEIIUfXoI5cQQgghhBBCCCGEqHr0kUsIIYQQQgghhBBCVD36yCWEEEIIIYQQQgghqp4FC8//6le/wqc+9Sls27YNBw8exPe//31cddVVh/+9XC7jhhtuwJe+9CUkEglcdNFFuOWWW7B69eoXVNFFDxPVUACDm63qZ/tWm27aIdw+G7eKgEUivNawh9eLCe+FxqzI3fhGLgZX32vLn15m08We4fmnVtpY9CdWDXF4E82OwLhta2SQi/TVjViVvJLf1n/iYqKmB6DzTiL8G6tM9PRQWvtNdnqtHYDmrXxaj51l69r6pE3X9jgXaRx6KRFU7LfjUj/I86eXWvFFZqgwsokLarb93+0mlrzmbFv+k1xgNtdo+5qJzLP5DwCZdjJXO+2YND7Ly69NkXmRt+OXi/Hyp5facV3++ado2sF3rDOxtifsHsLaBAD7r4iZWOuTpK6LeFsPvML29cr/sIKeTOAaAEp7giY2eqGNlV8/TvMHvjVX0LFYqC7h+T/kOVOTr4Gn5sicCz7GRVK9L7d9HfuOFc7MtvD5m4rYfZmlDA3xPZEJXK/+hhXJH7yUqLaDi58m1tv5ywTaASDVzYTP7fpnovEAABLv2MrPisRK29hcg+2XV7/+UZr/ezvsvgjY/EyMHwCSPWQPD9i9Mr2cZqeC9JmWyv9PkQnns75mYv4AMHqONUkoxe0zXWLuq78+aWJj5zeS8rlwfomE/dZ3AQ0OkV02h9Ln2bne/FPbzkP57VwPxe2YpkifughMOebKCnKH6rPpxs/lZ8VIxM5LH+mrP13zOM3/1YtfbmLhIVun9Hl8reVh11q6y87fMy7fTfNvf2LuJbQ0w++PJyJ/yHOmXFtG+ShR9eAEvyd6yD49SwTOSxUaHgBAtomJTvO0TDh9/Bxb1+bldo8AgMTT1jSCvSexdgLAbNiWFSQi86xOABAYJaYLjTwtE+T3JyoTgweAzofsnXLoIrv5BRI8PxNOZ+1qf4DfCdh7XbTXxuq38n1yag0xUxm25fum+VgV6m08F7PpJnp4/SMDRDifCJzXjfK9l5k01FktdIxu4Pt8bZqcEyO2rEw7b39sj60/M+PKtPPy04tt/uV38m8dB15uF3z4gK1ry07eV/EzbR2Y6Ume+65hag05P0+3a52NKQAkf20vGx7y/SLbxvN3PDK3XbMFns6UUVGqo0in03jJS16Cm2++mf77//k//wf/+q//iltvvRVbt25FOBzGli1bkM1aFzshhBBiPjpnhBBCHE90zgghxMnLgn+S64orrsAVV1xB/61cLuNzn/sc/v7v/x6vf/0hz9Ovfe1raG9vxw9+8AO8+c1vNnlyuRxyuSNfLqemHD/aIIQQ4pTgWJ8zgM4aIYQQR9A5I4QQJy/HVJOrr68Pw8PDuOyyyw7HotEoNm7ciEceeYTm+cQnPoFoNHr4z5IlS45llYQQQpxEPJ9zBtBZI4QQojJ0zgghRHVzTD9yDQ8PAwDa29vnxNvb2w//23w+8pGPIJlMHv4zMDBwLKskhBDiJOL5nDOAzhohhBCVoXNGCCGqmwX/uuKxJhAIIBDg4qVCCCHEsUBnjRBCiOOJzhkhhDgxOKYfuTo6OgAAIyMjWLRo0eH4yMgIzjrrrAU9y5utgbd8xNGAuSgCQOMu4oTQan9AjbnIAUCOOB61bZ8xMeZWBHAniZlW263NW7njQYK4OHlmrZMDc1EEuOujlzip1e93uGMQ15Z8mP+AX3atdXebWmXTtf+M5w9MWouSydX2MlA3xvsqs8i2YcUdtv/i63hbAwn73GniIuQiPGCfm1xu07E5BQAdj9g56LVTDYUwr//Em88xsWDCPnNoM28TK39ytU0708FdK2K7mLtk5U5KU6vsZPOl7bqK9nMXqvqnx0xs9I1n0LTMITS12O4hs9xIDx2/tg4nyW6b38fNDWlfzyziewjDO2P7mo315MPcHi02Mrf+s7MOe6Aq5FieMwCQbyrCU3ekb/0p7gSUf9g6ySTOs2PStIOv/0iffW4wbvekRA/f/woRuy77X2+tcIp+nr/YYu20alJ2/TNnPwCI7iKuQV22LOaiBwDpTpt27Gx+rjMnyUKDXROP/sv5NH+M7MHMSdCX4ntt0W/zR3bZs8rlTliIsDGwZbncVctsDInpUqqbjxWba8ydkdcTGHi1dQ1lZNdbx0MA8O2yGysrK93Jn8vcBb19dv8sOr4lMHfHHJk/QeIuDfBxSa7g65ql9ZKx8o/zfSUYt3Vg4/rVpy6g+b3EJY/1S8nhhAky19j6e/JR7igYmefkWMxV7ph9InOsz5ngQS+8gSN9M/IK7qIWfYLciYljnOuemFtnL5WeXnt3Z87eAB97X8LO/eKd9jwEAM9iGytRE2u+9/gn2TqzaZmLIsDdIX1pvnYz7SS2xo5L7Sg/p3zT5E4ZJi7Ejr6eabOx5u22rszBFQDCB2wsZ01waZ0AoGG37cMEedfMx3j+SF/lbWUw18F64hjocjdkTn6pJeScizmcOCdt+715Wz5zpnaVxcvh/ccc24fP5/t0gJiZMsfr2TBfF9G9zEnRtsvV14t+ZeNZ4m7JHDcBvi5Zv5R8vE+L/rn1r8xb8Rj/umJ3dzc6Ojpw7733Ho5NTU1h69at2LSJeJ0KIYQQC0DnjBBCiOOJzhkhhKhuFvyTXNPT03juuecO/72vrw9PPvkkmpqasHTpUnzwgx/Exz/+caxevRrd3d34h3/4B3R2duKqq646lvUWQghxkqJzRgghxPFE54wQQpy8LPgj1+OPP46Xv/zlh//+oQ99CADwtre9DV/96lfxN3/zN0in0/jLv/xLJBIJXHzxxbjrrrsQDNoflxVCCCHmo3NGCCHE8UTnjBBCnLws+CPXJZdcgnKZ/34pANTU1OBjH/sYPvaxj72gigkhhDg10TkjhBDieKJzRgghTl5edHdFF7UZwHuU9mbjs1xmLBuzsmK+tPvQmk+AiH7mmqxK4pI39NH8o7ctNzEmZh34oxFe/v0dJha8MG5iqae5yCMra5qI7jKBc4CLvIdGufA3x06hoo8Lz42ebQX1mMh582/5WLc+Pm1iI5uiJsYE5gEgcZqNNTxnY429WZqfmQ+wueYSXszGrCBgx1Y7MNNLuPBgLkqem7ChUi1vPxOZZ4KgTTt5/dOdZK2QNtUP8fGbWmbnpadARCIbeP0DEzET44Km3DyBCbcnY3wLrE1ZNd9czI7Lknu4eGyh3vZLgdRpZhFva+f9dg2OnmsbGzrI8+ca57ZrtnDCbvUvOp68Bx7PkbGZWsv3vxoiPhqI23F2iZEzMep8xD4z38zLDw7ZMWRi3v5urvye74uYWClAjE+IQDnA28XE8Au2GAC8r5jwPgAU/UQQlYjcx1/iEk8mYtpEeD/cy/fa8JB9LhPkDw1xkVcmfJ5ebse1+XGe3yVSPp+iQziewUTW2ZwE3ILuJp1DZLzYadvK2uTJ8fErBWy72FxLdfO56qlwrbFyACC618aTDZVL2LKymJg+AGRbyB2CrMHgDu6SwvYAFvO08MFmz8102rnuS/H2zzeUKGUrn5OnEt484D1qWiz7jqM/O2z/5YjAs0vMOjtqF2+J7KenvXo3zf/cd9aYmC9N9uNL+YT2PGUPgPbzDprY4G+J6juAIClrejFZT0TIGgA8C/DY8RCRcSb8z9IBLpFu8k41wvOHh+0+ObXUnvOutk4Tg4q2R22d2HkKcOF9LhDOy2fzsmkXuWev4OcEMz5jZbmE87NNdg2xtExgHwBm2thz7TNday2xluQm8y+92GEmVE/WquOdhsXDg7b/eZuA9q32vXbopXbvj+2pVNKdw8YU4CYBzMwlkOD55xuslCtc58dUeF4IIYQQQgghhBBCiBcDfeQSQgghhBBCCCGEEFWPPnIJIYQQQgghhBBCiKpHH7mEEEIIIYQQQgghRNVzwqoR55rK8AaPCKh1PJKh6RqetGLkz/ytVchtfbDypjKB8CwRmAeA+DlW5C0YJ2LaP7cC8wDQQES6x6NWZL7tcS4Gl+qydW16hgj/LefCe96Crf/wJt5XXfdb4d7QmC2r/mEu0j99YbeJNT5r07H+B4BCuMGmbbHCey4xbl+yMpHIoYutwDwALL7XCm2WAravXPkjg3YMmch8ppV/e2aC+gOvtbHWB7nI5GyICDL2W+FLb57PtfjLbayOCDdTgXxwQcZov50/Lpjwv8tkYKaV1cHOK5dJxfj6ehNrfLZyQwY2h9laY8YHAB+DtsdtB46dxVUqo31z6+qdXYiZxKlFsb6Ict2Rebjkp450ATunDl5cuRg5o2C3NDT08v13ar0VjvYGbPnFXq787mMi3ylb1/CQS2TVxpmYvEvM2090iplwKwBEyBHiS1UunM7EvH19dq9y5WfC5Uy4O5vje/18kVQA8JK+TtkjEQDQ8htb/wwxlMkTgfBDz63QJKGZjxWrf77ZluUf8tP8QWLow8YkaD12AADJHrv/MeFzVieA9zUzEwjyqwpGzqvsrgBwo4Ui6RbWpwtJy9IBXLw/S4T/MeV4ACHSZ/uP7T8A0LBj7roqOswETnUK4bmGFIlV/OwOD9u5H3+pnRCRp1zuEHaeMtHqZ35iBeYBIE8MPpjAdQ0RmAeAulFyT+2372ShUX7PZXOfCbczMXqAC6e7xLhjvax8m7blca68PtUTMzG2TlNLeFsz7XZgWP1rHfdUX4LsifbqivRimh3hA8S4ZtrGmMA7wEXm0+2V/+wMmyvxjXbvanyC34mYoHvbNrt+so28TtMbrRh7DkETcwnv+xOVGSLkYg6DFbIu68mYAA7zBTJWAC9rfJ29qzCReQ95TwGA1BJ7JkQG7Ph7iUHTobiNsbYW6l1mQnP/Xqk8vn6SSwghhBBCCCGEEEJUPfrIJYQQQgghhBBCCCGqHn3kEkIIIYQQQgghhBBVjz5yCSGEEEIIIYQQQoiqRx+5hBBCCCGEEEIIIUTVc8K6K3pma+ApHFHZZ25nADDTah0+On5hdfcLIV4Oc3djToTMBQEAYrtsjDkOuqhN27rGnrHDwlwUXfVi7nxtT3BnHP/4jIklV8ZoWuYEMnaOTefZtIrmDxDHpbqxypxgACBOylp6l3Wcmw3zb7eJHlt+47O2/JzD3XE2Ym1Ths+3DjfNv+VOdpOr7biy+edy/GMOHR2/sHWN/TZJ84+dGzWxTJut0/RS7m5RO2zrxdpa8jncMYi7ZZ6MlZ+sCQCIDNq+mlzNx4o5xLH+Y890Md1py+q4P0HTphZbh9Tx9bb82Q5uuTW91M415m7qItc4d1xnCyfsVv/iEyge+vP/SK7grlWp7sqcFAsRvn7DgzaW6LGxrJ06AICalB1D6hi4ABc3RiHC129w3MYyxN0vustxVpFuLQUcrsHddl/Y/NKdJnbfk6fT/CCuk7HHbAVS3Xys2s8cMbHMtnYTY46PAHdtZO6CIeJaBgDxl9gYc3wMkvEHgGy3TRwk4+J31J/Vlbl+Rvfysy7TSpxsqbsm7/9Fa8ZMbOJh61Dd9hCfa+PrbSzPXBCJYyrA6+pa13QOkLTMcfJQHSora/H99q4GAPEzmMOnHaszLt9N8z/ZYK3XIg/aC7Nrrs3v10r3mVMNXxrwHrVccjGerkDuRNEnXE6KFv8kcXcPV5ydOtsyx0GP45ypmyB3+qftpT5NXBxd1BLHOpcLXXjY7kkjYf5S4XISn8/eNzbysg7Y2Ewbec8hLoIAMBsmd1LiWOdyLKxZM21i/l12sBMxXn7Dw7b9g5vt3tG8k/cTqxdrk2v+Ff2k/bvZWPH6s3fF0Q2V/+xOwwPWSZG5SyZX8GdG9xInR+JE6Rp/dldbiGtopr0yd0cXzPXTY1+pAfD9KnmGbX+o37XWbCwwafvFtS/4pue2tehwkZyPfpJLCCGEEEIIIYQQQlQ9+sglhBBCCCGEEEIIIaoefeQSQgghhBBCCCGEEFWPPnIJIYQQQgghhBBCiKrnhFUjDg2X4fX/fmHCxmetSB8Ts3OJwTOB1MZnrXDh+Om8q1hZgUmbv1DPBVJzjTYeTNi6zrTy8plIXP2Qzc8E0gFgpsOKxNUN06RUfHLZT21bJ9dw5VFPgYjMdRKRwigf95btNu0QEUlkAvcA0LTTPjfTatO6hO/ni3kDQMM+K7yXXM7HKpBg5dvvzJNn8rm66lt2sJ97i63sZI8VmAeA2ZVZE2t40AovzoYdIo+1Ns5EUl3koravazM23ULE5BffSxSCAeSaSbtCdlwiz/H8TKSfrbXJs5p4+UTkvlRLTCa2Vq7Sm+y2aV1rpeHJ0Tl/ny1y4wkBIOcFPEfm3NRaLqbNhLeZGHiBCFwDXGSeiVEz0W8ACBORewYT2HbhJ9N/aj2fK14i5h7YZQWqXWLuxRarPMrE9AEuUrr9a1ZN3O8QKfXk7HMT59l2NTZb4V4AiBOR+WK3Ff4O13Mx8JnHrXuAJ2fHOtnD93om3p9ZgFBzww573rP2uzj9H+wl4Ld/32Vi+Ujl48cotvA6jey0/R9mc7Wbn/WxXttXbF661iozRHAZKhQabIyNdTDOx2/0IjsHvClb1oHNTGCemwwgZ/Nve24Zze+N23OFzUuPY6yW/P/mmZzM5rGHpjy1CY2W4PX/fqFzJlzNhLtje1zPImLS5O6etn4DAIBUt401k7uza43PNNm5z8pnAvcAF/5muMTAE2vtnuRPVPRIAK53Or7PzJJxCZCySuSZAFBLTKYmeoiZlGOsSw/aDSy1xKarI6Y3ADBxGimL7Z1EoBzg70pMjH1sAy+/7Kv8TGOsOd0q/+/7Jd/nGIl1dp+r77N94hKOZ+2Kkv5jZgQA76umXY77E3lVYOMSnKjMTGGh1BOThdkweaca4OWzfY3hT7gE5Z/fXNFPcgkhhBBCCCGEEEKIqkcfuYQQQgghhBBCCCFE1aOPXEIIIYQQQgghhBCi6tFHLiGEEEIIIYQQQghR9ZywwvMlH1BzlKhdIczFyJp3WOXqqVVWDXB0AxcNrd/PyrZllR09NWt1d1H022+HTOAeAKZW2VjzDpvfJYZeP2RF3hZS/0VrR01sZpcVfQW4IHjDPiaczMeKCa8yMW9fkufPxWysfh97JheomyEi80Wi5erlWsJUkJKJqTMhWoCPCxs/OMQYp5dYMWEvEW6fDTmEC5N2Ek2ttGmLUS6GXJOx4z/ZY9vkneHjx4TjQ6NW5Ntb4GtlutOuC3+aLEAAdSNMFdUugpKfl+XL2LpOLbPlR3/N1VenO+1YdT5gx9ol3M/KYmu4Nk2zY/d7567hUjYL/C+e9lQnMFwLb+D3H4W+VGXGGUygHAB8RKSdicwzgVGAC8L7h2zifDNfv4wCEbhmotUAECZi5kXiZ5Ijot2u5/pSfP7nO+268uRI+U7fBtuvwT6bf9LRVvrYQXtYlPv4/uMn/ZLuJPufw0wg20LDhkKkcvHpcK+t1MardtDc268kIv/jtv6lgMOkhLSfmSwsBLZWXO0vBYj4NhGDZ8YRAOAdt+PC2gQAvikbS6+351oDETQGuKFFqtuu4aAjfylgZytbF6xNTrpsxxSn+GIbeffcS0gxkwV+XnlRpwqpxR54j5qXLoOfxl12Tnvydu66xMAZwQlydsFxTxu0cV+a3V14fiZo30jEtDPtvP6z5LlMoN3ForOsaUbiZ4toWiaGzUTyc428fCZIP9Nm07qE61kf+sidLr7eJXxvx6U2XbmZFhP/zzVWnp/B+tRlMsAMFTLLyUuhg+cOtplY7TrrUJIf5ed02Wf7L72YmIaM8rka7bWxOrLWXIyfacti6w/ggvKhEXZ/dLw/k3Fl5wR7JgBMk37peNSeU9lG3ldsXcCxBzEy7XPTFsl5ztBPcgkhhBBCCCGEEEKIqkcfuYQQQgghhBBCCCFE1aOPXEIIIYQQQgghhBCi6tFHLiGEEEIIIYQQQghR9egjlxBCCCGEEEIIIYSoek5Yd8X5uNwdZhZZx6NCyKruM3cPF5lW++1vyd3WsQEAhjdFTGzsLFtZ5iwHAM07iOsIKZ+5EAJAkTj2Mcc/5gAEADVfbrXP7OKuBXVjxHWElOVyjSkQ171ov3VnGL6Al1+utf3ijdOklOanbSfmGq3jEOt/gDvMjJ1j0xaj1lkJAJq32uXGXPTqe3n53rztq6adNm38HIcTTNy2NbfI1rW+t3IrFR9xvXG5W06ttLGSz/ZJoofnryWOh7HriD0qgF2PLzOxwDhxwiH7BwAkV5K5RkzzJtdwx6m2J6w71eBmpxWcgTksMXfJ9BLuLrb4vrnx2UIJ+you/dRitr6MUvDI3PJyw0zqWlOIEMe5OLdhY2lZWTHi2AMAqXxlLmrBocqPdVZ+2h5pALi7HXNBdLoz9tt6ZZv5Wq9JESdU4uQXJGsa4H29EJhrX3SXbVeCuOgBgJ842bG6ptdyez/mhLh084CJ7dm+hOZnToKsrF/8+gyaP0KmcIi4PmW6eD/7UsQNjjgGdv6UnzXJFcS1mcwVlzsng851R/97A7aufj8f62IvWTAk//h6h7thl7VIZq3KtnCHsJbf2H4ZuoJcGEmdAFDXUOYEe9blu2n2p+9ZM+fv5Vzl59yphC8NeI+aQrPEWQ6o3PEvMsDPfnYmMCdDdscAgNQSu/biZ9q5G0jQ7AgfsHVlLtx11tgdAG+rf7ry/Xz6+x2kUjytjzyXudDlidsoAHjydqNs2GvTJdY67rTECTFN9tTmnY59lty/mesma6cb8k56TpamDG3n9+f5uN7fmZNkcNAmznbz/i9O23tC0U/u7o38UldzIGhiLndDRpKMa444MbreietGybv6K/lL7chg1MSiT9u+igzwfb5QT9bwJHM95e1nYzXRY5/puj+z/Wayx6YLH+D55+8BxbzLWXou+kkuIYQQQgghhBBCCFH16COXEEIIIYQQQgghhKh69JFLCCGEEEIIIYQQQlQ9+sglhBBCCCGEEEIIIaqeE1Z4vuXLv0ZtzRFRtbH3baLpksttE9q2W4XoQj1v6uQaItw2aIXbvLscss2b1plQmRQ1yzVDMRMmIoFETBDgYnDsua3bpk3swCu4mnB8PRE+389F8lofT9rnXhYjKR0i+0T4ndH5AG/rdKeNT55px6ruIB/rQriysc45xJAzaSuyt/heK0Y7ei5XWWx72AoKlvbYeZW85myaPxuzY8UEHWO7eP8xQXdvyNY/vYQL5DLzg7af2mCymwvPtuywQoGsTR2P8v5ngqrD+5fTtCBtZfU/cCn/zh8k2o9LfmKDw5ubaf7AvgkbG19kYq65xgwlGp+1Y1U3xsdqunNuvJh3iB4LdP2ygNraI/0zvJHP3xIR425/zI5f/CV8TjExcCaQzgTuD1GZeCybuwDgJYK+abKnelOO9U/qz4TD4y/h9U8vt/OXidEDQHjQ9uHoRUxQldc1tsvGsi02VnC0lQmnM5F5V18Vu+0dpEgEvl2wvW70P5fadOdxQd6V37Hqr6U629cHNjvqT+Y6iwXjfKzz5LqxaM2YiR2ENb4BgNCQjbG1NtFT+f/TMuH62GMOk4gGG8t0ckHfcjO5L8btADastWcCAMw8bs+Q1t/YuTZ0MV//swE7Bsy4wSE7jyCZ637is7Trx2tsEEBp3h5WLr8w04eTlaZdOdTWHunr4TCfe0x4nIlhewpceJmJQTcR0eeGXQmaP7WkycRKfnJ2dNHsmI3ZuRvqt+eES4y8EK5M+Du9mMc9edZXPC07Ez0Fsp7S/JxiYtyMjkcrH6timAl0832ukZxz4WGbP0GMlAAuEl5L3j8rFZgHuPB5mhgfAFzkn+Ef5HeyYrcVxGdi8qxPAcCz2OYvjVbe1qadtv5Fsla8ZE4Cjnn5Pf5OUbvWxgrEUIHNKQDIttk+YPV3zWk2rinyrsjqBHBDDWZSMetY//PjxVxlZ79+kksIIYQQQgghhBBCVD36yCWEEEIIIYQQQgghqh595BJCCCGEEEIIIYQQVY8+cgkhhBBCCCGEEEKIqkcfuYQQQgghhBBCCCFE1XPCuiv2/fN58ASPuCQ07OHpWp6y7kKj51h3hGi/dfwAgMbd1t6gRNytJl97uquqhnzUuhjU7+eOAbUZ6y4QOWAtL+LruBNLIGnzD2+y1kbhIe54M9Nq6xUa433FaHuCuztVSuCgtfHJLeJOkPXEcak2Y90dZkMOd0jiOjn0MltW6CDPH0zYcfVN276K7uHuFs+91bpmBOLE8ssBc91kTmypFdxJhLku1masE8nYRu7DVCRuOGxecndQoDZt6zV1rv3OPuX49t68wz7X5dATGLfPYO6EhQY+VjOLbNrBy+1YMXdOABi4yjopRvtt2rbtxN4GwEy7dZPJtDInE4eT3ZK5fV3KyvHKxeAlPniCR08k3le5Fjt/053EMWbI4aRDtko/cTZjzm4AUIjwdW3z8zmd7LT5o7ts2qzDRc5LHDqnu9ha5f3nH7f5vY7jI9tSmeuSy92POSkG47ZePuIiBwAFdgQN2etSKcDbGrnP3kESxB0p3MvPdeYEyByamLslAAz8je3YYq/d69mcBLi7I3Pcy7bw9rO5On13h4mV1/K7BnMy9ObI/OHbJ+2/lecM2DqdyV27Du62ro+BOF9XzCGVMTleT+ON546b2EjAOty59hXmchfps3UNxvm5ypwwU92kTV3WMRQAilNz+7A04/JxPLXZ99paeI5yOG3YzdN1PmD7eWSjtVF3OdbVjdqxm2mycyd9iZ1jAHdXy7YRx8cDvPzQTuIYSBzn2B4DAIFJG2N7Z6SP559pY8903Okn7FyN9doOCE44LONg9zm2J7nGitXLR1zcXfdcdtYyJ0VX/tgeW39PgbxTXuCaa3Zexc8k9SfjDwC1ZK7NhonjXhvf6BsfsGcac2yccQxfcdqe6TNkrvsTfO8NDxN3+g72WYW3v26isvEDeF817bLz1+Wu6J+0z82023Qud0U2B8KDNp1rrTHXRA8Z1tAIv+eOnzk3f6XvNPpJLiGEEEIIIYQQQghR9egjlxBCCCGEEEIIIYSoevSRSwghhBBCCCGEEEJUPQv6yPWJT3wC5513HiKRCNra2nDVVVeht7d3TppsNotrr70Wzc3NqK+vxzXXXIORkZFjWmkhhBAnJzpnhBBCHG901gghxMnLgoTn77//flx77bU477zzMDs7i//5P/8nXvnKV+K3v/0twuFDym7XX389fvzjH+M73/kOotEorrvuOlx99dV46KGHFlSx6O4aeI8S1Z5axdMVwla4tW7MCpLF1/Om1hDdU4/VonfCRLabdlqBteSruZpb8GErRupP27q6hPNHN1iROSacPmt1KwEAnb+yarLppTzxbMT2dWDfhIllVnMxdSbSPnmWFb8shLjIX2aRjTMxYRfj621f54hwrqfgEI4mgox9ryfzb5h/O/bkbf78eVYMf+kXuHDg0MVWzJiW45i/iR5bfu2MbWvzdocYOzEpmCLCwaEBvtYmiCBly3abLjTK53qusXLh9dqMjb3qn+43sW985xU0f9d97LlW5JGJ6QOAL23nwORqW/86x115lAjyB4jItmusG/bMTVskotUnKn/IcwYAQgdr4A0c6R+XmDa6KjPZYELQAIBBu359RHjehS9l5wQT+PZfaIWsASDTHzOxEtE9ZwLxAJDvtCqhnpx9gEsQmInMu/qKpW1+3NZr/Fy+V8R22D2oSNqa6ubl5zttBbxxq5TsEj5nz2VpXaLlbF6wcU3CmpkAwEyKNLaZiCyTfgKATJetV4oYL5QjvP9ZX6W6bflBIuYPOMSbO5kYP82OUsDWdfd+q7LrH3KoX5N1le3kbWVteOa9XzSx0279K5q//JgdqyIRfneZBLB+9eTsXuHJ8b2GicwXW2zHhnfwe+F8kf+aLN8/TkT+kGeNP+6FN3Ckb6bWcIF+37Q9J5qesQd9YhVXE8/FbIwLf/O9JzBp50nrNptu9AJef0+hsvEPD/O7ExPe9idsuuRanr9pp425RO4L9ayuVsw80p+l+VPLbdqJHnJ3S/DymSD8Qt4/s022rJkuOy51g3xMWL+klrC0fK6w/OV19p2y8Ydc+X2yx8aYyLunwAdw8my7J9cm7H5cT4w4ACC92JbFRO5d5e9/te3/rnsrMwgCgJLPlu8SfmfrenSDLX82zMtnRhGRAZuWmVQA/F7HTB6ie/lcSa618WgvMfnrcYj8D857p3GcZ/NZ0Eeuu+66a87fv/rVr6KtrQ3btm3Dy172MiSTSXzlK1/B7bffjksvvRQAcNttt+G0007Do48+igsuuGAhxQkhhDjF0DkjhBDieKOzRgghTl5ekCZXMpkEADQ1HfppnG3btqFQKOCyyy47nKanpwdLly7FI488Qp+Ry+UwNTU1548QQggBHJtzBtBZI4QQwo3eaYQQ4uTheX/kKpVK+OAHP4iLLroI69atAwAMDw/D7/cjFovNSdve3o7h4WH6nE984hOIRqOH/yxZsuT5VkkIIcRJxLE6ZwCdNUIIITh6pxFCiJOL5/2R69prr8VTTz2FO+644wVV4CMf+QiSyeThPwMDAy/oeUIIIU4OjtU5A+isEUIIwdE7jRBCnFwsSJPrd1x33XW488478atf/QqLFy8+HO/o6EA+n0cikZjzPx8jIyPo6OigzwoEAggErPBmLjpXDHjZj2dofibG3XrvfpvwFUtp/nSnFS9jwvUTZ3IxNc+A/U7Yus0K75V8VvT8EKSs06xIXtcveftbdtj6Nzw5amLTZ7TS/MObIiYWGeSCkuPrrMhi9pJFJhbdw4XvpruIIOCgFQ7MRfm0bNlh0zLhvqKfC9LlojbOxLxdIv3J5bZeTTuZyD+fK6yuMzNWeXLPu3j57T+z/Tp2jk3HjA8O1cvGmEB7LsbzN//W9v9Mh53/jc/y+bP4XlvY5Gl2XQxt5uNfv4/EhioXefzW16zI/MxarvJZ3GPXYJGMH1urAFC/384BKhx5DjcTqCXik0t+Ejexwcu5ycN8k4HSTOUGDScKx/KcAdxnTWZRGZ7gkf6J9DmML1CZcLxL5DbXYtdFKW/XT54IhAOAN2XnWnSXjc3EuRg5SPnMOKLzPv5/X3HYhjXtsutv5LzKxfTDQzzOROLTnTbG+gQAEuttu8L9bF/h66Jhh60AEz53GQewOZDttsrhNSm+1wVytl35h+24uuaaN0DmEIklHSKvjNAQ62ve/0xQP0zyu0wevBUaZbjE1KNUaNnGmMA+wE0eQoO8rEKDja365vts0GEyULBXMISHiHlRD98XykRUvAS7LgsNlQvCt91nJ9aUw6Sh/cy57imz6RzIUX1C84d4p/EUAM9R06rtUT6fmBh3y+P2nSKxypo2/a6c+dTZVwKn6QaDGTy4xLx903Y+ZtptW9Pk7ghwMWxWvmeXQ+B6BTFdcIi5T5D9r0TeHxrJOesiutfWP9PO21pLjMvqJmzM1VcFoucee8qmzTXS7LSvmPA5E4MHgMCkrWti1L5oxK/grhnt/2XXycjrrch/aDu/Jwcm7fsTOxNd5yR7V4pvtH3SsJfn90+T/GeS/m/je3d9n03rqiszL2DGW8VubpIQ2mb7mpk8MDMEgN/1co2VC8ezdxo212fa+FyfX69Sha9+C/pJrnK5jOuuuw7f//73cd9996G7e+4uuWHDBvh8Ptx7772HY729vdi/fz82bdq0kKKEEEKcguicEUIIcbzRWSOEECcvC/pJrmuvvRa33347/uu//guRSOTw76RHo1HU1dUhGo3iXe96Fz70oQ+hqakJDQ0NeP/7349NmzbJhUQIIcTvReeMEEKI443OGiGEOHlZ0EeuW265BQBwySWXzInfdtttePvb3w4AuOmmm+DxeHDNNdcgl8thy5Yt+OIXv3hMKiuEEOLkRueMEEKI443OGiGEOHlZ0Eeucvn367oEg0HcfPPNuPnmm593pYQQQpya6JwRQghxvNFZI4QQJy/P211RCCGEEEIIIYQQQogTheflrvhiMLzR4UJG3OEOXLPMxLx5h4vSPuJCE7LuAGHiouhiapW1vAgmuBVAqsu6djBntsFLePuZ42BmtXVcGz+dD3V4yJaVXO5wTGpgfVi5axtz7fNlKnctGXqpHYPAuI0t/zr39hkjDpvM8W6mg49V3bAta5bMFZe7IPumvOzjEyY2eX47zT2+njiBDtvYNDcSRdvj1mJm/AxrpRFIVD6mnQ8QJ51WvlYyrdZJkc2JjkfsnAaA6U47V1zrmq0rNq7eJJ9/gUk7hmNn2b4Kxnn50b3W4WTilTZdYcA6lgJAxyO2/IFX23XtcpcMjc39e7EAyMjcwaIZ4ChH1CRxxgK441q2mYx/F3fCRdw+N0jcXfMOc0TmMMXmP3smAJxx+R4T2/XjNSY2chU5VAEEd1jXpOQKW5ZrTYbPJHtdC3cdZu6ArHyXE1GRONaxtC4ny3ynaw+f98wUnyuMYB9xkSaOl664J/fC/k+y+af2DpEgTm4AUOy2czgDW/+Iw2HNS1wP82RMXLB9lbkmM8dKAChE7GCXAnavZGv6UFk2VnIMdYbMlXLEnmF1EV5Xz+PWnpG5nnJ3UIeTJVlrUznuxseY6mbrmqedeHiuy2Axx929TnVCo2V4j3LCdDvu2djg5XbsmAuhi4keW1akj+/TzImP5WcufAAQ2233jlyjw7KcwN3RbV3j63n/Lb3Lnl/j6/j7ky9ty0p12bWXP8DXHnNi9JDzj7kQAsDUCvZM267Ou4k9JoChLW0mxlwzi2F+ztQRF1rm2Mic9VyE77WxbCO/5yZW2v5jToqpNdwes2WrHRfWp3Wj/E7E3AHZM113GuZ6yZw8F/2Kl58mBq0uJ1DGbJjMtaf4XAdx3GV7ustdMThuK5bd5EhM6PyVrevoBtt/zAkWsOuqxjEmJl9FqYQQQgghhBBCCCGEOIHRRy4hhBBCCCGEEEIIUfXoI5cQQgghhBBCCCGEqHr0kUsIIYQQQgghhBBCVD0nrPC8pwB4KvgEFxm0gnoNv500sWI9Vw2dJQKlqcU2NuvQTawbs+Jn05224m1POERHCzY/E4mP7uHCf5lWKxzoyxAhUiIwDwBTK22MCd8DQPPTVpAx12jLD41w5Txv3raLiUwyMXIA6HjU9sHkapsutaGL5m98ZppErfCxp8AnXvPTtl1Dm22b8mGHoCjRcy4siplYLsrbv+QeqxKY7LZzNQeef5bUy5cmwvGLeP75YuYANyngBgVcUJ4Jd2ZjXMw422LTNj/F1XAnTrPii007icjkQ8M0/8BVi0ysTHZLl0gkNYo4SISPk7yvk8ttYUvvsIYKzEwBsGuo+AJFq09mQttD8AaOCKOmOys3Xoj12ljgMS6yysR7mRi3f5zPfw8R8053kvwpmp2KzDOBbd8uftgxgW0mPM6Fg4GpXiueHB7nab3kuMy2VD4uwSG7fkoBm9/V10V/ZYYowTiPh+J2rY+cZ9ta9vM2xXbY+id7KhPDBwDPoN1/8hEiksyvJfARkX9GqrvyOjFcYvoT6ysTOvYPcecBtlaQsmPa4BDfHr/Cimd7+nifBOJkrpBYpI/XNfX6KRPz99qNga0JACidaxd8oj9mExLhfYCL7y++37Z/9BwuaOwyfxBzSa4GPEcdDS6BZSYoz+5paYdwfXjE5g8kbLr0Yl5+wL4+UYHr0F6+dhJr7DyZabNpI328fAYT6Xf1X//rbPn+hONOO0KEu4nweHiYmyGlOyp7hWZi6ADQssOWP9Fj68oE5gEucs/uJIV6x52C5KfC9S6DF3LWMzHzTDvv/xh5r02sJCYJu7nAeZAYRBUP2PzpxXyuLnrYjuvEabYsV/6OR2z9WV+NbuDtDw/aWHCC79NjG2ws0kf6aoCfyYWwrQNbl7XEjAEAJlezSUCMj0YdZzoxuWkge0iG+66hZN5peD3nozcfIYQQQgghhBBCCFH16COXEEIIIYQQQgghhKh69JFLCCGEEEIIIYQQQlQ9+sglhBBCCCGEEEIIIaqeE1Z4vv5gEbW+IwJqmVb+PY4J38XPazaxmVYuUsZEstu2WeG22RAX7hvfaIXrWh+03brvCi6c17rdxgIJW6eRV3KF66XffmHfKWdDtq4uMW1GIUSE4xv5tGJjGBqzIntMzB8AJk6zY9D0jB2rko+P9dDLrJgr62tX+VNEDLyZCEdOLeNjwsqqTVk12aKfC7wevNCaJ8wssvOvfi/vfyaIP7XS1mnxvVxk05tnY2XHZHoFFz5kIv2d99uyonuzNP/USivoXfLzvmZCqcw8ggnMA3xfYML542fwdV3yVSaS3bCPi0zWD9h5MfGyJSbm2teK86ZQ0SFaLABPfu7/9kT6eJ+mLrbOEYW4nVSJtbycYosdhHCvXdMl7pFCBeWLJK1LDLxph10rTGQ238nNHJofssKjibV2njfvoNmRIMKjLjFtBhMTZ2LyAJBrsX3ABLZdgrolh0i3TcfvBcxkoBSwdXIJ3zOReSZwztoJcPFfLxEZhsOkJLvezvVizpbvjfMOZGso01W5+LSXCNKPnVeZyC8A5JvtXs36monxAwCIcH+hgSdlY8DGKt3Fy5ohe0g4RQxZXMYLRKQeESI+zgTywc0T9lxjO9aT4+UXI3PbX5rh94dTneBYDbyBI+PKRJ8BoPVJewEfPt9xKBC4GZQty3VPjr3yoIklfmbvSWMbeP39k/a5TCR+8mz+ohF92t6pmp6xaZlA+KGybPkLMUfINTIxdZdBiY35p4nx1wHe1+ycaNlp95PUEl4+Mw9o2GtjTGDeBduTU0v4PZudM5EBNtd4WekO+9xsm927XGLm8TNtv2S77FxhcwoAEqtsPESMG1Lr+FyNr7cToG2bzd+8k2bH+Jk2FuZeWPDk7RwqhG264QscxmdEUL55p61rcoXDDIvc9RiBSce+QNbFQkwK5n+XKFf4nUI/ySWEEEIIIYQQQgghqh595BJCCCGEEEIIIYQQVY8+cgkhhBBCCCGEEEKIqkcfuYQQQgghhBBCCCFE1aOPXEIIIYQQQgghhBCi6jlh3RXjZ3vgCR75Bsdc2ACgRNwVM8QFz+WY1/y0fS57Zi7GFf+X3Gnj46eztLz80Ii1CJjutE4qi7/P3TVKxN0jvt623ztDsyPab508Gp4kVigAJs9vNzHWL76Mw/GN9Ctz/HP1dTBu+5A5Ltbv5309vcKOdWC7ze9Pc2et6aV8DObjcqestYZVOHBZrKJnAkDLDlv/wh7bf5lWnp+5FsbPsXOt7mCa5md19aWJC+GDDidUh8PKfEbP4e6SDXtsWanF3DaHuV42PGfblV5KLBfB52poX9LE9l0dpfnre21jG/bYdBmHOyJgx4XtFZnWCl2X5K7oJNsMeI/qxvAQ3z+CO+xcYY5nzDEGALxDdq5mOitzATwUJ06u621hjc3TNH86bl2H2bnUsIPPKeYk5SOOj9kWmh1Lf2YPofgZfK3H9th29b/B9os3VdmeDAA+4lhXbOZjzZzomJOjy/Gu2E0O3LjtV1YnAMh3kr2euHP6+nj/sbFirp/ccZE7KbJ54XLy9ObtWOWbbdpsil9B02ttW5mTY3Cc9593yD6XjRVzfAT4Gk4v53fQcH9l12jfFI8z10c2fi0bRmj++DZ7LwsN2WcWIryt2Rbbh4vvtWkHruBjXTPP9Wv+38UhplcV4Kk7Mi4ux7epZZVZAbpczMLEHc6bs7GpFXzeMidFdqcNH+DnVHSvnSfMBa/xCV4+e6cZuJzt8/yeXibO1t3f52u37w22Dg27Kz9T6PsncYdzuTuyfmXueJE+PtYu18JKmQ3bukYGbL/OtPE1zVw7Eysr/9mZ1u32pajks/cs1zuVjzj25Ym7aPPT/AI8udoOTLbJ1j/6BL8TMXdDhsud0jWujPCgHYPYc5W7jrL9ItZr34mSK4hbLwD/pG2Dj7wq5hppdgpzMnXta2auOu7Z89FPcgkhhBBCCCGEEEKIqkcfuYQQQgghhBBCCCFE1aOPXEIIIYQQQgghhBCi6tFHLiGEEEIIIYQQQghR9ZywwvPRXsB7lCZceOcQTZfa0FXR8yIHuEpZ0W+/8xWIGLpL+C4bq0ykcPG9XLTz4IVEjJYIlI6fzoeKiZkzgfbQGBdpZOSWNdF47Le2YsmVMRPLtDqEk4lI+dRKks4h0MoEUpnIvEu4ftW37CCOr7Pjx8TsASC6x/ZhLkqE90k7XfViwpFLf5qg+cfOtSLnM0S4nM0JAMg12cLCA3as0svqaX5mUpCN2fyTPbz/PQUbDyZszCWGPHaxFQ/tupvPtVSXHcNMqxVUXHTrNpr/4Hs3mNjIe+y6aNzuEOQcs33FxOwLDTz/tI8ZClQoMg8gvWTuXC3NVL7+TzVm68soBY/MucgA3+zTnVaktBCx/eoSjmfiswsRiE53krVCxLjzvUxgHig4RNbnM7WWi/QygWzW/pxDeL4Y4CLpjHyUmKc0WOOMUp6viUifrSsTSS/7HX3SZe8L4ccqMx4AgMiDNm2yx5bvEjOPPcZE3m1ZLkFjJpzOhN+DDtH0PBGeL5Kuds31VLeNBYkYPBOYBwBvgN+X5hO9ZJjGR3ZaMfbwkF0/6U7X+FvjgAYy/gBfL8wQge3/ABAigsKJ82y/TDzcQfMXyX6xED3qLDE5GCOvBv5x3lcXv2LnnL/np/O4fQHlnyo0P14Lr/9Iv3rzlZ/JvrSdIw37+d7BSKyyM8LjEG5m7zq5mI1F9/L6j26we0Jg0qZjoucA39OivTYtE9gHgHS7LT/bzFdEM7m/Fcj1l4mRA7xfSuRMqRtdiBkDMT5ziHk377R9kK9n+SsvP91Bxi/B0zKRfXb2dPya7/Op5UFb/mLbpuAo7//wsO3rWrJWPDl+njQ/Zff58XX2nuIyE5ppszE2/5hAOwAk19r6l/p4Wz3kvYiJzC/+ytM0f+8Np5lYYq2d7P4EzY4Yef9lc2WmjZ8TbA9j77+uuTrf5KDoeE+cj36SSwghhBBCCCGEEEJUPfrIJYQQQgghhBBCCCGqHn3kEkIIIYQQQgghhBBVjz5yCSGEEEIIIYQQQoiq54QVng8ki6j1HRGL6//zZTRdsc6Kj7XssCJzyW6u0MpEFv1pK7DW/DQXIx7abLuQCcQNb3IIvEaJyF6cCa9xMbZZooXKRO4mV3MxdSZSXkvaDwB9V1vh82V3pkxseJMV+Aa4SHrDHjJ+j8VpfkahOWxiTGAdAEbPsYKCrP9mFnFBz/r9tg+nybR0CXp2PGLn0CwxOdj3upijfCKySMav8/4EzT8bscrBgYRt04E3cJHG2mG7hnzJyswAAKCxl4k8WuFJl0lCodeO6+i5vKwl91ihy4HLbf2ZwDzAxe8je+1YMYF5F+yZM0v5vrLqa3YOTi8hJhWOtTp/XIv5GgxUUslTkNrpGniPMkUYuMwh29xlF1toh91AXMLxkT67VjJdNm1sFy9+fD15LhHITrfwvZ6J1JcCZP44RL/zRM++odeeay7h+iwRvm/eQZPi4MVk/RHhb5dwOBOZd4mkM2IP2bMiSwT1PTl+LrNxZeV719rzEwAS621bmXC7i1LAls/GivUT4BJOt+lcc5WJ1Kc7bayxeZrmT++0Jh+sr5O/5GLsPlLX9Hl2/QbJ+gWAQt6OP2sTULkhQylfuUh/uNcWtuQnEzR//1W2r9hYsToBfF4wPPReCjx475lz/l7KWoMIcej89+LIukyucBk02VgtMTNiYvJA5SLxJWJuAwCpbps2fMCmTS3h+fOt9k4TPkCMRBz3ZCY8PdNmY7Phyky/ACDlELnPNdp+bdtG3h9X8LLY+2PdqI21P8zX7lRPjMbn4zIYYWMwG2ZnIj8nW3bY+NArbPtrCnysu+5ldbJ9NXQR3zzrD9jy/ZN2rCIDfO9iIvsBkr//ddz0phi2z/WS9ecnBlkAsOhhOwEK9bb9M9zLDf5J26/Js7lI/7Lv2LSD5PvDvvedQfNH+myMicRn1vDyQyPk/W/a5p9t4ws7vM3uV2wPcpn8zV8Dlb556Se5hBBCCCGEEEIIIUTVo49cQgghhBBCCCGEEKLq0UcuIYQQQgghhBBCCFH16COXEEIIIYQQQgghhKh69JFLCCGEEEIIIYQQQlQ9J6y74kRPLbyBI9VrfJZr6Wdj9jvdxGnW3SC6h7szjJ1jY/6kzR+M8++BnfdbJ6lco82faXU4qUxZ1wbmpOFynCv6bH7mDun6nlkgriMuJ0hW1/H19TYdcYIBgMigrRcbK2+BW1GwtiZOs+maiWOIi7oxmzY8xJ1U4ufYtHXDtl9dc3VyjXWXiPbb+VPy8fqzcU2cZstPnN5A87P+82WIu9tWh5ULoX6IO6kxmLtlijiJhO7k82/JT6zr5p4brDsjAMTX2XlZqrX917adO0ENb7R1DSSIE4ljXU+tJPNqgLirEXfKQ9h+Ta4k+Wcq+3+KosMFTgCz9WWUgkfGi7kgAkAKxHGNLBWX4x5z5yt2W3fEMeKCCgCBODmXHrTucMzZz4WXOL75hnj5zKEruaLioihj5/FzjTkRZlsqb5cnV9m6cI3VFHG8y3baNclcCAEgOG6fy1w3i73cidhL5hVzTHS5brHyPdw0idL5oD3D4n9u3QkTAV5/X8qWn2uxzywRF0UXzI3N1X7qLllv19rkcv4A5mS58SpuBbr1B+tNLE+cRJf/F3eS3PPH9qxi7Rp6Be+rSufFQtxFmUOqy4Ux3zx3XEszlTsOn0okuz3wBo6MAXNRBLiTYnKtjUV7ef5st10ogYTd01k5ANDxiI0lVvKyGMFBe8/NNdp0rvanF9szIdpL3nOIsxsAZNrtPGcuigDgydvnMndAV19FBmx8dAM7U0gHACj5mZOkfWbjLl4+c1KsGyV7P3H2BriTon/MrnPmwgjwtjJ3yZKf50+stTGWv0j6CeBOnNyJ0bX32bEOTNq6evOO7wcvsXM9H7P5u8h3AgBo22bfP/Zdwc/UgxdWdv/h7poAUJkTJcDPxPhG24bIbuLw6nARZrBziq1/AIj0zX1uqVzZO41+kksIIYQQQgghhBBCVD36yCWEEEIIIYQQQgghqh595BJCCCGEEEIIIYQQVY8+cgkhhBBCCCGEEEKIqueEFZ4PJMvwHiVWN/RaLtzW9KBVLuv6pRUYnWnnYmp1w1Z4Lr3OKrT6prgYb6W4xNhnWokYHBG4ZqLhABcjD0wS0erlDjFjUlbLU0ThFUCu0U6XfJgI/5/pELR81Ma8dqicpDttH7Q9boUTU11cDLjrxwdNbPA1i0ys5Smu0MuEl3NNVngvG+Plzyyy/TKziAgfxvlYD15KxHSJIGdohI9fstuugamVZP4R0WIXmVZb/1yM54/227GKDNo55RJzH7w+amLN9/AtLDRm10AgYes6uZYL17N1weY1E5MHgI5H7VyZXG3TFaNcpJeJ9Nfvt+UHEzz/+Olz+6XEtRwFIXfpFI1H7rOGDl6HoCtj/CK7LvlOwQkP2bLYnuiCi1FXnn/oioKJNeyw54pLjB1ddrMP7LLC+QAXKWfC+/lmfi9gwuEMJtoNAO2/tuVniCFJigjUA/ysOHixLav1Mb5/1OaI+PQKmzYS5/WfWG/rv/ryQRNLjRA3BAAj59v9B0QkPzToMGnotvXytJBzNUXKAVCI2P7z5Gz/u8aPGQrUfcOKP0+d5zCJICYDD957Jk0bIttFbIedf3s+yNdFKU42Z7KG0p28reGhytZwnusZI32eNRSoidt13badX9am1hLxYWEIJADvUd2a6uaHcm3ajmfTThvLtPNxbyTGQYl1dj9o2M3nY7qDCVTbucdE0wEgF7MxZhpRckyb5Xfacya9yCZOLeF7Z9OuF2Z8wITnXfu8lwjXe2z1afsBoLAlYWK1v46ROvG+btlh5xAbP9dYRZ+2/eojgv7x9Tw/G0OW38c9NzD5Ciu8XkzwM4HBDAHYvHAZlDDzAyZmzwzaAKD+gC1/NmzTJVbxyZ58vY1Fn6ZJwYTj2Vpr2ekw6Wu0/cL6P/AU7/+6UduGqTW2rPo27ihR9Nv7MzMJyLbR7GauVfpOo5/kEkIIIYQQQgghhBBVjz5yCSGEEEIIIYQQQoiqRx+5hBBCCCGEEEIIIUTVo49cQgghhBBCCCGEEKLqWZDw/C233IJbbrkF/f39AIAzzjgD//iP/4grrrgCAJDNZvE//sf/wB133IFcLoctW7bgi1/8Itrb2xdcsbp4CbW+I8pitb/gynFMeDm5wopJM4F2ACg0WOG4zjuZGDYX/ZxcU5noZmiMlz9NNN4ae60Y3PQSLhyfXE6Ey2P222Xz00QNEUCu0eY/eCEvK3TQ9sHUKpuu41HeV9FHD5hYcvkyE3OJ7Dfss30Y3m9FUydXc4XVgausyDwTiRzczOdawx4bY2LkTHQcAHxJ29es/KJDd7F5OxMKteVn2vmcZCYHbEwLRDgR4GLsrP4umCEAE+5ObOQqnfVP2XnJhBcBwJexa2B6qW1/toWPFWvXyu9a4WSXcH3Dz54xscFLe0ys9UG+BU8vtbESWRfBBM2OurG5/VpcgED6i80f8pwBgPp9NfAeJcyaTVmBTAAokW0x22LHxJ/i5dSk7Fh7h+xeE3SIwY9fZOdfuNdWyu/Iz4Srg3GbziWm783ZstgzY700O9BrNzYmUA5wkXmGf5yna9pl13X8JQsQ2b/YPrd5h02X7+R71cGIHetIn33m6EVcOD/cT+4gnfauU4g4xJd32Pie3BITKwUcZxURbmci767xY8/19dnxdwoCp2z9mXhzwSGmXvQT8WQy/v5uvlg9j9s9oBDhbS2Q7SLbbNP6/Xysy3FuvjAfl0lEx0O2Dc/+mX2ma00ViaC/N2f7/8BmfjGJzVsXxXwt7E3vxOQPedaUfEDNUVezSB9fux6y/xbq7dgz0WwASC+2sbZHbf7kCp6fiWlPkbSBSZ5/NmzzR/dWZqQBAP2vtffXKDFYcrU/fqadz6xOAFA3ap+bWmMvf+0P8LXDDMWm8zYt248AIPyfdvNgadn4A1xkfabN5mdmBgDvQ/ZO07qNZsfIK2xfZRL2nuAyGQhtt3sKF+7n/Zdpr+yceKG43nOYSD1bF06TiYQ9513vNIGEjZXYOUfmPwBku+39cdk3bfkTp/HygxO2DUmfjXl/EaP5M2TLZOd/6zbeV5M9c9taylb2TrOgn+RavHgxPvnJT2Lbtm14/PHHcemll+L1r389nn76kB3A9ddfjx/96Ef4zne+g/vvvx9DQ0O4+uqrF1KEEEKIUxidM0IIIY43OmuEEOLkZUE/yfW6171uzt//+Z//GbfccgseffRRLF68GF/5yldw++2349JLLwUA3HbbbTjttNPw6KOP4oILLqDPzOVyyOWOfGGcmuL27UIIIU5+jsc5A+isEUIIcQS90wghxMnL89bkKhaLuOOOO5BOp7Fp0yZs27YNhUIBl1122eE0PT09WLp0KR555BHncz7xiU8gGo0e/rNkif2ReiGEEKcex+qcAXTWCCGE4OidRgghTi4W/JFr586dqK+vRyAQwHvf+158//vfx+mnn47h4WH4/X7EYrE56dvb2zE8POx83kc+8hEkk8nDfwYGBhbcCCGEECcPx/qcAXTWCCGEmIveaYQQ4uRkQb+uCABr167Fk08+iWQyie9+97t429vehvvvv/95VyAQCCAQ4ELnQgghTj2O9TkD6KwRQggxF73TCCHEycmCP3L5/X6sWnXIUm/Dhg147LHH8PnPfx5vetObkM/nkUgk5vzPx8jICDo6OhZcsULIg5L/yA+aRQ5wy4Rco20Cc5HzFhyOfcQxj9G6bZrGp1ZZK7rx9cwJhJffuMs6BBzd7iP5ueNAtN/mH76AOCP5+FAXwjZt/X6HYxJxyKjfZ2NFP2/ryKusZRxz7HM5cQD2uc/+qe3/1d/kjkkHXmGtmKbXWtuMJXfy+ieX2z5kToqs/wGg8wHrrhSYsOUX6vlY7X9VZY5jTTsrd6dMrrRzrekZ6+IFcHfElqesY0frvfx/OQ9cY500A8nK3E0BIBuzadlaB4BMq20Xc1KM7arccY05KTIXRACY/vAZJtZAHIJCo9y2ZabVLgK2VlzMdz0tWcPWE5o/1DkDANPLyvAEj/RteIjPCY+d6siuJY5pQ3z+RnfZ9cPc6UIOCRc/cWJMr63McRHgjnfZFuZ4ytvPnHCKEbtXJNY6XNxIWuYiCABe0tfMydE1VhnieplvtmPlTVW2pwLA6KX2DrLkBzz/yPl2/+l47X6b8E6+gRTJEDLHxMRamh2pbhtjrpds/AHuDoiuGRMqxSt/mS922/yRB7mzIFsXkbiNuc6qkfMrG1ffQ9xJdYqsa28Dv4N6dtk2NKydMLH8w800P1tXzMmx/cwRmn93d6MN5mx+l+sYc31lTo4u19j5Y1Wp69WJwh/qrAkkyvAe5Ya2EMc45u7GXBgPxcn7D0nLHGgBIE+c/NgzXc6obduYC7eNMRdHAMABWxbb58KDPDtzoXO9fzEn8ejT9u7FnOEAINdo29BI+pX1KcDflRbSVla+P8Ec/3hfMyfO4Kidf6MX8H2286e2r/L1bO/h5Y+81D7XP0b2o2nef7E9tq/THZX/ghp716wljpmRAV7/BHl/Co2w+c/rxBwL8/U0KWbabB8w10ynk+Vue1ZPLbV1dc0V5uTZ+AQ5J6b5vlKpE6Zrrcx3SC15j4O7IqNUKiGXy2HDhg3w+Xy49957D/9bb28v9u/fj02bNr3QYoQQQpyi6JwRQghxvNFZI4QQJwcL+kmuj3zkI7jiiiuwdOlSpFIp3H777fjlL3+Ju+++G9FoFO9617vwoQ99CE1NTWhoaMD73/9+bNq06b91vBJCCCF+h84ZIYQQxxudNUIIcfKyoI9co6OjeOtb34qDBw8iGo1i/fr1uPvuu3H55ZcDAG666SZ4PB5cc801yOVy2LJlC774xS8el4oLIYQ4+dA5I4QQ4nijs0YIIU5eFvSR6ytf+cp/++/BYBA333wzbr755hdUKSGEEKcmOmeEEEIcb3TWCCHEycuChedfLAYu5yqHvqQVKQsPWUGyqWVcfqxMeiBLRGvbtxKFQnBBvbqDrKzKxTgL9VY0NRvjQqrBhBXui+0iwvUZXv7kOVZgteRzKr8bClEisvccF46L9lmVudRiO67TS3n+GqLx3P1D+8yBLVZgHgBadtgH5Jptv45u4OUzQf582PZ1bYZmR8lnn7vvNVbMfOUdSZq/7LOKhPV77QQu+fhYh0aseul0pxUjHPtjKxAMAIu+atOyddncvoTmZ2K+hQZb/9DByteKq6/TS6z4IRNvdRlK7Hut7WvvDBF05V2FujHbhmki8rjvap7fN87EK235Qz18X5tviDBbKKGPF3XKE5iogTdwpG+n1hPVcwANO+z8b+i185cJpANAtpOLt5p0LfxYZmLQIGL0VDQcgC9l50owbtMx0W8AiPQxMWpb12yLw7hkAeLF6eV2r6gh+fMRh8A4OQL84zZtIcJFUllfhcn4D1xBDiUA4X5b1/5H7b5YdMwVJqjPBImZmQAA+Iig/sR6O/9YOwFQkflizj4zGK9cuD9Lxip0JTcpwQ+tsDebl661UvTbtMz4wEfmLwAEiXlEicwfAMi12OcWeptMzEvE5AE+Bz05Oy5DB4nAPPi+lCfzn5lUAIA3bhchEwR27YvzjS6KucrNXE4lcrG55wwzfQKAXJudT3WDdu6VYg6DFHLPGSYSYlFihOOCPdMlUM2Eowv15J1k2rEeSP7atE3nyh9/qZ28taP8oKkbtWWlu8g7HUkHAG3biPA5EdhmouEAUCL7VPNOG0stcZhJ7bWx+EY7WPkY3+eYcDkTTp8l7zkAF0ln59TK75IBBDB+pn1A+IBNl2nn7Q9Okr2TvJO77jRsDSTW2WeWdvO9P7OG7YmVm7GUfLZfXXeifKOtV5m86628g+/T+19VR8onJgUJXj4TtGd95aKmYNOy+Zfjx5wZq6LDIGk+L1h4XgghhBBCCCGEEEKIFxt95BJCCCGEEEIIIYQQVY8+cgkhhBBCCCGEEEKIqkcfuYQQQgghhBBCCCFE1XPCCs/Xjc2i1ndE1NVb4MJvhZCNMeFy3xQvJzRmxdCie2y6wCQXDR7abLuQCd+5xNyYID4TnQ2NcoHbyTVWDW5mkS2/Ns2/Z675khUEHNjCheeZcHv902MmNnqJFY0FgEy7fe7Embaurdu5SGBypW0DE65nAvEAMLnajlUTEXmcJXMKAEJjdg4wQ4DQQZ4/G7P1b95hy9/1l0TNEUDrViL8m7BjMn46X9bM0KDxWSIGP8Q7YOwsW//YM5WbPJz+vwdMLLuWCAyTMQUAb8GWFUxw4cNAwtYh3UmE21/GTQoC4zaWI4Levikufji1ysZWfeY5E8ucu5zmn1xjn9u42wqKRgZ5X6e65o41E40Wh2jsnXvWZDr5+mGC8kwMngm0A0ApYJ/rSxGBbIfwKBNPLbZYkd35QtC/gwlPF7vJuTZoBUpdMDFqJmQNAK2P2bk6eikXSY09ZtvQ8eCEie19E1cpDcbtGGRJt7A6Adx8hol5M4FygPe1n5gEuGDzgs2rTFfl/08ZGrJ7QMZhhuDrs3NgITsIEy5vu8+2f6Kb3xXQQupE1hozKACAcL8dl0LetsDLpx+FzSkA8ObtGBQixGTBoUfMjILG19t0rvnD1mDnT8ldyyGI7E/xes0n2MfzB+Nz52qR3H8FUAgDpaO6sGkXv7vMjNr5kFxbucBz+IDN75+s3AwruZbcs4jw+qxDOL9EpmnsOaJc72DgcrtOWf2nVvD8LQ/YCuQaKxfpZyLzLB0AJFfYuqbW2MT+MX5O5Fvt/pUdtWvXx3Xb6V2h8QlimuF3jBV51ZteTMTIJ3n5TCQ8PGhjvX9hDbYAoPEJG6ubYMLxvPxso50XbKyjvTw/e259HzF5cHix9dxkB2Zmsa3T2Ev4A1zzisFE2gsx21f9r+P3t9mYnWu1CTYvKzekWPoTuy+x90yAG7ox4wQX4+fMLas0U9meqJ/kEkIIIYQQQgghhBBVjz5yCSGEEEIIIYQQQoiqRx+5hBBCCCGEEEIIIUTVo49cQgghhBBCCCGEEKLq0UcuIYQQQgghhBBCCFH1nLDuirNhD+A78g3O63BsGTvHxjoetar7zNkO4K6J0122W4o+3lWd91vHgtkwcQHs4o4DHb+2zjh9V1onhqadlQ9V9/emTWx8PXfsmzzNxr0z/LnMNXLgqkUmVnSYc3lnrLtC3TBLyV0Tonts3Je2seFNLh8oW39PwdbJ5aTBnBSbf5N0lGVJL7N9zZwQV/wnt9wI7LNOlvGLrDtV47PcMYsRX2/LDx3ka63zQTsxhjfawc6t4xNo5FVLTWz8HFvXNV+18xfgTojTa3lfNW4nTpa/tWs1uZyvq2i/Tet7ytZ14HLueFVotvmH/8haLk4vo9nR8YjNn2mzdWWOkQAQHpLjVaXkI14U/UfWtssdkbmYNe+w45/ucriwESc3Nn7zx+5IWTY2elHljnkNO6w7Woq4K4bGef2zxPGOOTm63CETPbZdNSmHE2yDjfX+RdTEfA5nuGyLLasQIfeCFn5WMCdFRs16btvMjkBPirjTRfhYM9enYJxk7+P1YmOVJe6wzHERALrusx27/1W2UwqO+vuJQ/RUt425nP3attszpO+11qGrsZOfv+nxJhNj4x/p4/fCdCeJrSWWkeBrIDxo+yXRQ7NTJ8/wkE3H9h8AeNeGh0zsPx+71JbTyZ0o/b3kvkumarbbZUU5N3ExV7k716lMuoPPvZk2O3eYu6DLmS0wydYkcSZdzPMzd8amZ2xhiVX8ohycsOts/6vtM+sG+d7jJ05+7Y/b8idO4+UX/ZXfdVhdM+3EmbuLP5M53kV2O14gCOEDdu35pyurEwCUfLb8XCN5z+FbF+pGbdqmZ4jjusMxL19vy2fujJ338vzpDjIvSaxtm8OJtIm4KLfZtCUf779a4lrJ7i/smQBw8BJ7ziTPsHO1/QGeP7XE1mumi9/fAqO2D11riBHpY3PNjn9yBd+/6w/YtIOb7TNd+xK7qzAnTFf+ht3PzzFeP8klhBBCCCGEEEIIIaoefeQSQgghhBBCCCGEEFWPPnIJIYQQQgghhBBCiKpHH7mEEEIIIYQQQgghRNVzwgrPz7R44PUf+QZXCHMxtI5HKxPZdomJDxHhtGU/zprY5ForegoAJb+tFxOZd5Wf7LYqd+1brcCbN8+F65ig3tgGK3DeQIS0XTQ+Y9sPcOFvJhJXaOAijb4p21dMYHj45XxMm7ey6UoExnfw8nNRW37jbiummlrMlZNzMZt/ZJMVQw6N8bEavsDmb9pp6xpfR1RfAeQ2W5F5RsMe/u16NmRjTMzfZfIwvs6uAV+aCDzv4WuFzZWOB21d93yAb0utP2bGAzzt1EpmMmDXpWuspjuZqKGNMeMJABg/wy742oytU8NzNDt803YNFIihRSDB80+tnPv3Il/SAsDEOsBz1JQtBfj+E+yz67JSgW8XXiIIy0THASAYt/tHcMjO/1wLr//UWjtXvQ22At4+slGAi4znWpiYNxcE9RExbZfwe3Z9xubvs3LuLpH7IBHPz5NxKVzEheP9D9mDKd1p80fuIwcYgGSPHYOmOBPDp9mpSDr/P0mHSQDpv+AOO64uk4Jn/8ymZcKxrvoz4X42f5jAOgD0vcem9e0iIsN5l/i0jbF5merma5XNH+8QP5eZycHYeXb8XCL/lZoc+If4ZP/60MtNLEiq6k3x8j1ET561yRt3mKz0zJ1rpYwOG0YgAXiPGhfXO0HDXhsrcN8oysSZduyW32n3+fEz+HxmBlMj59rK+ohot4vu79uzZ/wMPh9Zv0wtteccF9gHCkQMnQnnA0C6g5guOM4URomI3BeJmVU+VrlwPRMDd9WJ9QETU2emWwB/f2WC/i4x8FzMxti8WIjJQr7LzlXfA453MiJc3rrNPjO1hGZHjLz/JFbauroMSnxkrJjxQPHNxDUGgO9n9gI5m+BlZbvsILSQd2I2/wHeVyzWspPfCeJn2vXqT9h0rnXJ7rrsXdNV//n7Qom/uhn0k1xCCCGEEEIIIYQQourRRy4hhBBCCCGEEEIIUfXoI5cQQgghhBBCCCGEqHr0kUsIIYQQQgghhBBCVD0nrPB8pcTXEzFmIhrKBM4BYPUX9pnYwdctNbHMIp7fl7HlMzHryR4uplapeKOnwMXcikQ4kAkMZ1u4ymXTM1ZkbvwMroTKRMaZGHvJIZLI+iWXJ/l9fFoyQc3aGZK/lvdVwx5er/kEEw7h6YSNJZfbumZa+bdjNi9Do1ZMMH4OF+Rc/U07WWYWWTFmLprOxSOnltm6dj44Q/OnumxZgYTt6/r9NDuml9r2r39Vr4nlvrGW5vel7bjk35LghfU2mRBrf5KITAJAvsf2QSluhVoLYb6uWL+kO237Zzpc6omVqZ/WWn1pAEDX/XNVHmdn8yB6tgJAYKIG3sCRsSn6HYK4ASJoSoTXA3Gev2mXTRt/iZ0T4TMnaP78w80mxsQ8nRBBfS8Rc68f5HOSiXQvWjNmYiMt/LANP2bFzEvncuH34ONE+H2tVciuSbmuMGQMSPtnUlx8OfjycRske4pLuJzNASbSzkS/ASBC8qe6bf09OT7XmMh8kArf8/0vNFjZHSo85BC+J8LlvpRN6zQOIPVn4+/t43eVYsT21WV/9riJff+h82h+1q/+C8mcAICddl4wkXtmXAAAZ13wrIn9doSYzPTytuabiUlJhI8Lo9DA5mrlhhL1j801mpktAPZWLXKxecLzRLQcANKLiZh1HzG46ub7dOeviBHCWXafqyX3+UP1smUxgxsmGg4AoREbm1pmFzoTLXeVxQSyFyJ8n23ic3d6cWVtzcf4c+tGiRnMhB2X1AJ+nmRsg42VfS6DNduuyECFitwA8tTQgOz9YUf+RnL/IcLpybP5Qdf5U3t/zu+1c2VqBS+/btTGxs+09W/eyfskvt6mbdtm+zrdzscv027zZ5bbF43aO+3dDQCC07ZeybMdKv95WwdW/myYr0sPeddmMIF5AIjuJfN6ia1TYh3v67pBYvw1Qu4kjrm2oLvuUegnuYQQQgghhBBCCCFE1aOPXEIIIYQQQgghhBCi6tFHLiGEEEIIIYQQQghR9egjlxBCCCGEEEIIIYSoevSRSwghhBBCCCGEEEJUPSesu2IhVIPSUY5X0X7uLpEPE3dD4liXaeNNZU6KzDGwYQ93LJjutOWXiOHaijviNH9mWdTExs6yD2j+LXcsYC5uoQHbVpYO4P3HXOhcND5rxyUb499OmZMfyz9N0gFA9w9txVKLrRPH2EbeV5lF1t0hF7OuM+Eh3lczrXZedGy1Lnx9r+eOXYB97nSXHaumnTx3rjloYiUfc6xyuWjY8tm82PNHDscxMoUjxIkt1cXdOdoet+P39EyPiXkcjlvjp9u+KjzNXUvq4rYPxjZa11G2VgAg9gvb12xfyBEXMYA79LB1FdnL5zpz+Jw4zfYrc0cFgH3vnDsupUwJ+CVNesqTayrDEzwyjswFDuCOY6EhOyZeh2Mec1IMknma6I/R/OXldv7WEMcclwsac2JKn2ftOYcc7qz+Ibswh/pbTKyuhVt+5ok5XNbhbljTaec1c1J0tZU5ETY/ZOs/sZ6fFfleu6+EybgyF0EAKESYkyFNSskR186yw42NkSH9Fx4kZ32Oz/XIoJ1rI2Rfz/Ltl7ouFslQZ+30AQDUrLeumy4nRVp+v50r/5XaaGJl4sII8PHLDtm7GgDEiBNlpsvmL7Zwe6hdP15jYjNkrXtdTpRDtq3Micq1L7E57MlV/v/fQ1fMPdhKMwXgexVnP2XwFADPUd1af4Cn4y5idj8okLs7ACSJE9002Q/bHnU4ozZV5q63+Bd8PjMnReaiuvg+fk6Mr7OOv15yz40M8LWbWmL3KdeduG7Uzv3wCHGBj/FzhvULG5d8jO/dbdtsPEF+9iS3jjue59P2npr02fz1B3j5s2HbL133WHfnXddzyztPwr6rMtfPyFP8nJ+w13/q4heY5HOdOXzWpm2b4ldkaf6GByp7p2L9BLicLJnjOu//5ArbLv8g3+gLMTIvybyo32rXD8DnKnModbm2ZojDJJvX3jQfK9ZXkz22X5ljJmAdOkszjgNtHvpJLiGEEEIIIYQQQghR9egjlxBCCCGEEEIIIYSoevSRSwghhBBCCCGEEEJUPfrIJYQQQgghhBBCCCGqnhNWeD6QLMN7lNBqeL9DzPa0ehMb2mybteQeLpI4erYVxKsbq1zgtX7Iiqn50jY2vJkrtDIx645fW0G1+Dou3OdLE4HTOiKaWusQmSQCt4vWjtC0ue+2mxgTGe+8P0HzD22O2fKJSL0v6RB+rmfC8TatN8qV80tTNv+Se6xw3/BGLtzX9oQdF98uqx7asG4VzT+10o5LtM/Oy31XMOFCIBezcTb+jbt5+6eW23VRS5ZV5wN8/meJyGByue1TZrwAcPMHJnzP+sQFMx4AgJlWG/Nm7FwrRHlbG/bZOG+XY64SkUfW1swinj+TJ+vCajHT/geA2j1zBTWLXHdTAAhM1MB7lMlJeJDPiUSgsjEpNPBymHB9MG7HL0BiAFAK2HrFdtl0oxdZ0WoA8Kbsc9t/YIVXmUA+wEXK2TPzKYdAOBHz3rBqH02681erTYwZAkT38rbmI3avSayt/FxnIt1MOD3fzMWP/eO2X0JEoNwlvO4l+ZkYuj/F8xd6bAOyLSEb6+birSMBh8r5PGK9PM7axfo028zHJPg4WUTr7WHl22XbBHChazZ/mnc4jAtebzu2vIMvbCYy711r87uE85uesXO46Lfzl61/gI9hww47WdOdPD8zCWBi9MzMAQC88bmdXZPlwsWiMvL1xMjg0mkTa/4uFwNPLbHnVGCUmEY08fJ908Q0gwhvM4F5AJhebNMygeuhl/K1y4T3mcB4rpH/jEa+1d5/awo8bcNu2y+jG2zasEO4faaNCWeztPxMnSFjMBuu/Jwqhu1aa95py2IC3wDQssPm94xOmph/sJHm9xDjGyYcP9nD28TyM4Fzlxkay8/Stv8Xf39OrCR3mgrn36GybF1Z/pLD+GDF1+z74+CVi3lZeTtXPYP2XdUlHE8ZJcL3DpH/wGRl+0LJYZDD5iAzCXC9P9aOzt1vShWeM/pJLiGEEEIIIYQQQghR9egjlxBCCCGEEEIIIYSoevSRSwghhBBCCCGEEEJUPfrIJYQQQgghhBBCCCGqnhNWeL4QqkHpKDHggS1ctHP5rc+aWHSvFW6bXGsFdgGg+WmrUje8iQnXc+Xm5Ar73FynFYhjAt8A0NBvy2di2ky0GgBmiXbjsjutSGV6KRd5ZMLxNQ8Q1W4AQRCR/YwVjksvs2YALpjInEtkcHK1HZccEUht/TEXGZzssTEmMt+x1YrRA8CeP7LPbW9faWKu+sd22b46eKF9ZtNOPtbegu3/0IijMEKCiD+2bLd1Gr6AiyQ27bSxxT9PmNieN0dp/jQR32x81orZDlzOBU0D8cpEJgGg0GDb2kQEORufsWsFAHLNdl1PLbOTNTzkGisbn1pm/0+hhutmO/YLInDs0Ogv+ea1lYiGi0Nkls7CU3dkIJjoMwAs/ZndF0bPsfsHE70GAF/Kjj8Tc27awf/vqRAhe22XTRfu5/Vn9Yq/xMaYQDcAZDptXSN9RNCY7MkAF17fNb6Gpi0SQfIYMQQYe0nlV5hixNa/hgjXAlyku/1Ma8gS/qY1YwGA8fU2llhvFzsTqP9/NTORfKdd7KFBftZ5++y8nFpry58vGv7fwcav4PAYyBKReBCRXH83V85PR+x9pfk+m39iPRdDDw2ReUnmFBsnAPA5ROZpWrZeiHB+OxFkBvgczrXYdrE2AUCRjKFrDR4P5re/qLOGEkjMNdOaOJOPUes2G6sjIvNMYB4Aonvt3GFi6j5+9UGmvTIx6Fyj4564y87zmSaWluevJWZKHY/aZzLRawAYC9t1Eu3laesmSF2JmLyfiPG70rI7meuexvqQidynwd9fa8i4ZElfL/4FNxjZ907yTje9lKZlBBI2xuZlw17XflTZPuXNV97/9VbLHYmVfK3E9lQq0s7nDxN573jEphvexJ/63F/YC5zHMVeyXfZlJ7LbTgD3XLd9mLCvr9QkAuBjUCLXB2YGAPB3NbYu2Pp/IegnuYQQQgghhBBCCCFE1aOPXEIIIYQQQgghhBCi6tFHLiGEEEIIIYQQQghR9egjlxBCCCGEEEIIIYSoel7QR65PfvKTqKmpwQc/+MHDsWw2i2uvvRbNzc2or6/HNddcg5ERK9gqhBBC/D50zgghhDie6JwRQoiTi+ftrvjYY4/h3//937F+/Vx7muuvvx4//vGP8Z3vfAfRaBTXXXcdrr76ajz00EMvqKLLfpSg8dHXrzIx5gTS0M9tzKa7bBes+NqwLeeSDp6fGFE07rLuAMX5bmf/j/EzbGWZC4HLXZGlHdtg3Q3dLnQ2VhzjdR3ZaGPhAfud1FNwuIORsloetvYKk2sqd3xqe9WgiQ0nrbsmAORa7Bxo2GOdWPpezx2rgnHbrulOm65oTaAAAJ6zkybWdLsdK+Z4CXAnk/g6W9eoY65H9rJxsfNq8b3csYqtlZFN1kmxfh/NjlzMxop+O9dm6xxzncwf3xSfqyw+drFdBLMh7gTKnHuY4yHbaw5RmZNkPszXCnNNZe6Yvg5u2+p/bG67ypWbcJ5Q/CHOmZp8DWq8R8bL5ZhJnRTJVuFyUvIS15nYLjv+CeICCwD55src+YLEhRQAChFyLpGtNsiNmBCI27LqB627ULqTl8/cBRt6+RWEORnG89bJkPUJwB0mg0M2lu3k+YsRci5N20VZdIwVc3Kk5Xfzzmauh+FeO9kyXXyuFiJ2XFifsDkBAB7ikJfssW1icwIAdVIMD9lnFse5i6Gf1Cux1qZj7p4Ady1ldXW1n80LlxNmiewB4TMnTGykuYnmD47bGGuXL+Uaaxtjjo/MsRTgfcWcYMv+P5xj4x+aP8Q5U/LVoOao+07HI7w/J3oq+9mDqMOtc6LHzp22bXaMU0sc85ncaeqJ4x9zYTxUPnFyJI5tLhdidnc68Crb1sYn+NkRHCV3SmtOCQBIkXsec7fLOwzjc222X1uIC7nr50mYY136mimb8GnuWF4Mszlgx/XAy3lne/tsbHAzTUrxvTJuYp47m03MNVdcTn7z8RJnQAAITNrnZojhcWSAr5V0R2VrzUPc0gHAn7D5Z5qIC2GI3zM8k84XCENw0KbNNdqyPAXe16MbWLTyPb02zZxAbTqXEyZb75Mb7WILhPkF2rN73iKs8J3mef0k1/T0NP70T/8UX/rSl9DY2Hg4nkwm8ZWvfAWf/exncemll2LDhg247bbb8PDDD+PRRx99PkUJIYQ4BdE5I4QQ4niic0YIIU5OntdHrmuvvRavec1rcNlll82Jb9u2DYVCYU68p6cHS5cuxSOPPEKflcvlMDU1NeePEEKIU5tjec4AOmuEEELMReeMEEKcnCz41xXvuOMObN++HY899pj5t+HhYfj9fsRisTnx9vZ2DA/bXwEEgE984hO48cYbF1oNIYQQJynH+pwBdNYIIYQ4gs4ZIYQ4eVnQT3INDAzgAx/4AL75zW8iGAwekwp85CMfQTKZPPxnYGDgmDxXCCFE9XE8zhlAZ40QQohD6JwRQoiTmwX9JNe2bdswOjqKc84553CsWCziV7/6Fb7whS/g7rvvRj6fRyKRmPO/HyMjI+jo4MLtgUAAgYBV7qw/WESt74ioX+J0LlA602rF0JhI+77XcTG2hl4b73/LIhMLHeRiaiUippZptd8OQ2Nc+I6JiTOR+JbHiDopgNELrcjf5JlWDDE0wIe6fr9t19Qy/u2z8wH73MSfWDH1whNcJLGGaO8xkflAkve1L237cN+TRPm9mfd1404ryJiL2fFv3c7LZyLzdWM2LZuTAOC7x87hTKtN5xKOz8aIcC5ZFgcu5ePXtNPWNZiwYzp6LhdDZONXJtMqH+X9v/he+4Cp5fYBLpFHttbS6xwq2YyM7T8mfA9w84Bov+0rttYBLlxf8tm0LuF6tgcw4wPfXodw/rx5UXxBPrp/WI7HOQO4z5pKyROBZ4ZLzDy2w8718fU2XbGFC2/WRexcLw/xc5HBxKg9ZE113cl/SmF0s1V0jb/EPjPSx9dUqtuuv2yLQ/j0bjuO+fVkree4eHJ6rU0b7LNj3/YQzz/VbceqGKjcEKVSkfmalEM8eZwIh5PimcA8AISGbLu8pPuanuEmIxOn2Xox4XGXcH7DDtvXTDh9aj2f60x4n4n5p7r5XKtUZJ6tCQDw5h2C+gQ2Btm83dhdhhT+C+3dLv+wvdcVAy5DCdsvHse6YDCRebpX5PhcNe1ytPNE4w99ztQPzn2niZ/Jx2g2bOepP2HHY/QCvnfWFOx8HCUGNy07+N7B7inTi235lYqGA/w+U3CIwedjtl3eenumTp7N87dstfN0agVPW0dE6svrUiaWe4If/g277RhOEDMSNqYA0LjLxqZHSce08jtFqN/uM75pW1Z42GGms4GIiQ+yuyvNjul0i027mJXFy2dmPOycS3fxva+WzEE2LzPtrnu6jbG56hq/lh3EOICJ2fv5WmPGBeEuO/8AYCZj9xRvn/0471pXsV4bY30908b7mr1/sXnB0rmoSdu1WkPuaQCQn9dXpRnep/NZ0EeuV7ziFdi5c651xDve8Q709PTgb//2b7FkyRL4fD7ce++9uOaaawAAvb292L9/PzZt2rSQooQQQpyC6JwRQghxPNE5I4QQJzcL+sgViUSwbt26ObFwOIzm5ubD8Xe961340Ic+hKamJjQ0NOD9738/Nm3ahAsuuODY1VoIIcRJic4ZIYQQxxOdM0IIcXKzYOH538dNN90Ej8eDa665BrlcDlu2bMEXv/jFY12MEEKIUxSdM0IIIY4nOmeEEKJ6ecEfuX75y1/O+XswGMTNN9+Mm2+++YU+WgghhNA5I4QQ4riic0YIIU4ejvlPch0rJtd64Q0cEfXzTfF0TCSu/RErhp7o4QK9TDgtGLdici7hvbqDVqSNicy7xNyZcHm60z4z/p4mmp+JdLdutWKIUyu5cB4TSWd9CgDJ5fa5sdut8HWWCEcCgC9j40y4u+joaxDxzKadtv6J03j2bItNG91jx6roc4jZEkMDVlbn/bwDZ0n9U12VC8QykXxmHDCzlIsJ52KsY235TGAeABqftc9lwu25KO+/g2+3IsWt37F9Ekjy/GOvyZpYcBdRiAcws9SOARMjdtGyw3ZCicyLxt1cZXdws1VfZMLDbEwBoFhnxzVAvCem1vG5Fjg4d2svFR0C3wKe5hw8oSPjMH4RnydMJDy6i5hZkH0GAFLdlQlfe/NcubMIGw8SjVKXmDsTyGYC5c/8DysmCwA1eZufiVYne/j+48lV7n5QJNqj/iHb/hARyT1UBxtnwuNTDuFyP+tXUieX8HuZmA90/tTuvwcvdo2VjeebiUhtv0MMnOjBT621dcpHKr8C1hCR4GALF56fIoYKbPxcwvtsr/QRMf9cC59rTBC/+SFbfpqYyQBAMG7byvrPhedxe98skjEFgPROe7cLkfuuN8/zF/3EZID0n+NaR/eg9HLbVjb+gDUkKM1U3k+nEtNdc99p6g/w8cw1knvqXjvPB7t4OcHRyvbZ1BLH3YMcP0zMO9fI69+w18Ymznxh94/oA1ZgO72Yp820k3cahxlCusvWq/mHVrl7sofXP7bHxlNLiJFDmvc1q2vjEzaW6qbZ6TpPrLWx5p02BnCR+Zk226bGXbz92SbbVtbXfiKGDwDJFWyu2zN13HFPrhsl7+rkncQlxs7KytcTM7tJXv7I6+07SeAp+07SuJXf6Vb86bMm9sxP1tC0xeV2By8SQ4LaNH+BZmPA5irrUwBIrLN9FRit/J0q22Xr3/iEPdMnN/I7xXzjoGKF5ipV5LklhBBCCCGEEEIIIQRHH7mEEEIIIYQQQgghRNWjj1xCCCGEEEIIIYQQourRRy4hhBBCCCGEEEIIUfXoI5cQQgghhBBCCCGEqHpOWHdF3xTgJW5G82FOgDOLrJVCbBd3RwCIu8ZT1jFhpp27I0ycZhX+M+TbocuxcGqVjfmsOST8Dsc57wxxt4vZdLlFDhe2cevE0Libpx3abKdLqmDbz1wIAe4ONBuy6aL93DEpubyy6VpLnGAA7tBZCNn+czlpsjFkTiLTXbyeLH9k0LZ1/HSevzZjY/60dbzo+AV3nQiNWNeKQr1NO76Rj19txnZMgZiWlnw8f/Qndl0ObrHuIN4kr3/tHuuw4zmbLBYAl3buM7FH9lvLL9dYT66ubK7NvIHb9nR8347L4BbixFbg67p+ry2fuXu97uwnaf4Ht5875+9Fh7uQAOofDcHrPzK3MsRxCeAuZAyXiyd1jKOuwS7HQLYv2rOGufABgH+cnFWdNm1Dr2P/4qY3htylfAOeidvNPuhwB2T1oum6+P/TeYjrX/gxW34+wp+b7iT3gh023dh5PL83bu8LE8Txseyv3ImOjZ8L5k7JnBhd/czmMHPSLPbyDmzb9Xsq+P9w9R9zrSw3k3UZ4PUP99oOKF1p7Wmz49YdGgAKZPxc7oL/47KfmNj/t/d1JubN8fxsXbFzNbGWb+LMNZI5rLlgexCbK9FLhmn+6bs75vy9mDthXyteVKaXl+AJHpnXLhfE2TBxXG8nLmgOZ1l2p2EuchnyTFd+Rt0oL3/8HLsm6wbJ2bPGcaDkiWPvWpvf41iPgUnbfy53v/Ez7TOYY2DY4YQZGrLvigdfZveetkdd7oq2rMmz7ZkQHKxwUMDHhTlmumDzj7nwAfxOw96JXPkrJdbL4wXihMicFF1zzZe2Y+VyYmSEtlsnReY6Out45m8eXm1isYviNO1Mf6OJlX12XWfbuOPzQXKv9aZJXdv4ORPabfsqt27GxIpk/QJATdqeC4Ut9v1tScg+EwBGBueeM+VSZY6t+kkuIYQQQgghhBBCCFH16COXEEIIIYQQQgghhKh69JFLCCGEEEIIIYQQQlQ9+sglhBBCCCGEEEIIIaqeE1Yhcnp5CZ66IwJqLdsrF1mcIgLl2ZbKRIMBYHqJFVib7uTfA4PxyoTrn3sLFw5kAtNMoDyzwiFQS4Sr2TMbt/OhTmy0gnyps3lRwT2V9eFMK08XdAjSzyeybZDGs7GlJpaLEeHIFi68Fzpo07K6hoccwvkFG28kAruZVj5XZhbZ/DXdVmTP/xgXw2VzPRuzZbmEQ4s+qz7JhP+XfY/PtUwbES4kGoWFMB//dKeN1ffayqaX8PGjzxwnDQDw0FNnmhgblVwLH+s6MldYX9U9YYUnASDxJ1ZQse6JqH0mEfkEgJmz7bxoarCC3j964iya37ds7t9LdksS/4/kGbPw1B2Z894UF/j2EPHWAhHzzHc6VP5z9rlMzJoJfLsIEfHhfHPlabMttk6pbi7mHemzaZlAu9chRu5le92F3Dgi0x8zseguIl7sMAlo/4E1qTh4sW0XaxMAlIhwe7qr8rFiQr/ZbiKGTwTSAcBLdHKZmLxLUJiV1dg8bWKFnU38AQQmBs/GBADSXTbG6tq0g/ffxHpbFluXYYdJQpbs62kmMk/WJMBNJgqO/xP+zM9fbfM7zpWKy4rY/ME+PlcSa23a8JB9JlurAF9DbKyLD3eYGACU5rW1lK287acyoRHeT7lGcvcgwtXs7uWC39N42rrRyoTbRy+ofJwrFbMHgJYueyZkHmoxMVf7E+vsPu9N87Vbm7Z9neq2c98/yfMfuNReCuvI60usN0Xz5+vtnuQfI++vZD8HgLqtdlMt+YkZGZlTLiJ9tq3MzAzg4zpN+i8w6jhn/XYOFUn9XUYadaM8Pp/oE3zvDE6wdw3bfjYnAD5/wgdsuiTZowGgTEy6JpN8YfoS7F2PmMGEeV1ZfoZ/kF8qmi85aGID/XZdejJ8rJtWT5hYnc9+7JjM8HeqQmxuu0ozlb0n6ie5hBBCCCGEEEIIIUTVo49cQgghhBBCCCGEEKLq0UcuIYQQQgghhBBCCFH16COXEEIIIYQQQgghhKh6Tljh+dCgB97AkW9w01ZzHADgtVq2VAyvfn/lYuKFEBGYTVcussiE6xt6+ffE1Aoicpi05QcO8qGq329j4+dY4fBAnIvBvfklj5nYzz93EU0700rDtiyHwHySGAIs+6+4ie35Sz7YHiKy75uy6eqGeV+XiMhfbcamcwnnp9dZpcvF37f92jjJhZs7HrHq3+PrrfCkq5/rxmz92345bGLxi7hALKN+yNZ17CyuEsr6KjRm5y8zTgCAqVU2Vqq1bYrs5eOXvdAKJ9c9xUX62bxggvalFl7ZUtyuYdau+iEufphngoorrXjo+av7aP5nJ6yg43TGiml7Q9wkoKZhblk1GSnPv1CY0C0TKHeJiYcH7VwfO8/OHyb6DHCR71Q3EX53COdn7ZSibXKJqeeJnnwpUJlwq4v8w1wlf9Fe+9yR8yozvgCA5Apbh9XfsOK/o+dykXxPrjKhXpfwOxMTB2xiV/6e1+w2sV0/XmNirvbHHrNzsAwb8zXw/IzV/5+tJjb4dxdWnD9oj3oqMA/w+0opYMffl+J3DTbXKzV+AIBsp91Xw/0OkftmO9fY/GFi8gA3tGDzIraL52d7CMD6zyXUa+vP9gBX/YstcydhaWYBiuinEPX9c99pplbw/mT3VHb3CEzyucvMbPL1Ni0TmAeAVLeNNe+0sXqHaUfmHPtSlvURg60Ev2fmnrKLN7PGdkBtgq/HV2980sR+dccGmpbVNbzdCl+77rQzxIzJR8TIn/sgr2uZjAETM3eZTuQabYydCblGPtasrMAkMb2YcLw/k7Lifrt35Bv53hMctWknzrRpwwcqv1P4rD+T02QhR4y76g+Q9ec4J+aLoQNAiojBMzF/AMhebO8k+VFuphUi6z21zr5TBMJ8/y0n7LsSG3+XGRZj7eohE1sVIQc9gOdSZF0XHBcggqdxXrsClZ0z+kkuIYQQQgghhBBCCFH16COXEEIIIYQQQgghhKh69JFLCCGEEEIIIYQQQlQ9+sglhBBCCCGEEEIIIaoefeQSQgghhBBCCCGEEFXPCeuu2LC/iFrfEee3VBd38mBOiuEh6w7gT3N3h0yr/c7X0G+ddVyOc4xczDoWMGc6AGjaWZmLE2snwF0nOx60bRrZyB0Tvnu3dVKseTWxpwBQ02stKhr22HSJ02h21JLHDrzaOi6EDvK6BpJ2DKc7bVtd7o4M5rjXsIePSeedxCEmTxz7/Dz/5GnW3YK5tmRWcCsXT8FOguf+wjop+og7JwA0PstdH+eTa+ZrpTZj+3pqmY255ronb8elRHYg5qLoYtHmAzT+irZeE/vSg5tNrKnZupsAwGzButkUNydNbKLA96Wzm6zDyHTElrX1tytpfkZNxpblchKtOW9uXYs+l7OWaHrCC6//SN8m1vJ02eYK9xWHC1m2xa7L0JAd0/Ry7pjJnBSLEbumXS5wzLGNxbgzIG8/c2HzruVrij5zPd8sin7rMOQjj3U5vrEx2P1O65oV7ufZmWtUptP2tSfncPIlToD+btsA30Pc3vDpe6yTYo6Uzxw3D5VPwwZX/2PQ9tXuW883sZo8P1PYvMgSI02XkydzYsx02VjRcdYWyLoIDtl1ke227lQususrdw0skP5jaxUAfClbL5Z2/ApefmCXXStFMv5NOxwOX2RfYvsCGxMASHfNrWtNsbJ7xqlGITx3XbrcEVnfh0aYsyw/03ON9rlecvfKNfL5wO7pmXb7TJdjX4i4EzJcjnfMsbBlq10j04t5/zEnReZCBwA1k7az2Z081c37mrnusfy+Xt4ngYSNsXc9l7sjS+ty7GWwedWwz+4z42fwA4WNIZs/C3HsY45/rjZFBuy4+NK2rAOvcowfuVNPkTOl5Of19yWIk2SX7b/pxY77d8HO6+blkzTp5RftMrFvPXmeiUVCfK5PE3tsz/kJE8sn+Fz9kyW/pvH5/HycfwAYz9jJMpm0sRJZkwBxV6wQ/SSXEEIIIYQQQgghhKh69JFLCCGEEEIIIYQQQlQ9+sglhBBCCCGEEEIIIaoefeQSQgghhBBCCCGEEFXPCSs8H0jMorb2iABvYJKL8cbXWUE8Jvye7uQCrUykPNdo0zIxewCYtZqfCCRt2v9/e+8eXWdd5/u/997Zl+zcdu6XNm1TaBugTSktlNIyClQZFA+KIvLDszhHz7BkcBTUM+r6qTguBxjnzIyjPwRxFHDNjAzogKICYoEqWnoDLG1pWtr0ljRJk2YnO3tnX7L38/ujQ9L0834OO0pp9u77tVbX0k++3+f53j/P85C830cvoNVR/5KNMTH1sSY3MXDb1+GzbP3ILt7+xg1WTHvXzVYgHQDQbOdg/IhdQg1beFt7L7ZtrSfC9az/AFDeQ4R399t+JSMuYrZR265yMq/D89yEm237j51jlR9DA3ysWfsZldu5ywATmSw/YGNMoB/gJgtsrwTskjh+XbJXqnfbNXHwen7/su12r551/0ETO/zBubQ+E35PjvO5+smBpfb+TVYRM+Tn58oYEWqNHSLCjS6CoKON+Sk/+4b5uZStsmsl3GqFq53eKlo/cVJbc2P5G2ecaSRrPfAFJ/cBEzifDqk6vs9DA3aufUwjNMjr54jIbWWnXf8jHVx4NNBDRHZTJFe6CN/7Yrb9rL53CxdTb/3lMRM79B5elovc23tVdHHxYSbS7yHj5yZcz+7FTAKmUz/ZZc8Px4Zcr8vuz/oJcOF8aihABNIBoHabjUXb7f3TLVwMNkMeLZnIfGjARTieLIuz77W5ovPTxHkHQJDstfk/sMny8HU818Ta7B70kf0DAOlaUpaUCwzys54aJREx+vJu/lxzrN3G2PrJuKw1LzkumMi8m5mBr2vqGvIk8zNTOtOo6sqh5AQDGG+G792BJXadMJF1b8ZtnO11E4127VTt43kmTsqOl+U/p8Ehe/+R+bacm5kW49gSskdchPuZGHp5ZIyWHQvYRZ0pIwYlh/neGyXnRFkvEel3eSfxjxIzGXLMuJlZlRCR9ap99vmbrSmAmxd0fcCePZW7aXVE9tr66XJmfMD7zwwBKsh7Qs1r/EF7ZI5t61A7GyuXdxIyr6xNwTKe55zd9l05vNu2Px3hez1y3qCJLa47Qss+020P+tYW+0x1VhV3CPlNdY2JsbenRXN7af3hrP3YMTxu98rWnW20fnmDff/68LlbTezh362i9bMnraFcJr/f0dJvcgkhhBBCCCGEEEKIgkcfuYQQQgghhBBCCCFEwaOPXEIIIYQQQgghhBCi4NFHLiGEEEIIIYQQQghR8MxY4fmRuQH4ApMKfGP1XHjPybMHOT8Xfhslus0lrxHR2X4uxjtelt93wtnruPDd6Cwi0ErEBL2HXIQLSdlUxJaLv9OKvgFAT8AW9iV4W4ODtg1M5NxNULPpRRsbnkfEfCt5/US9LcvE5Ks7k7R+9zutSB5bF6k6PtdV+23MP5KfmDsAlPfYWP9y26fwEd7/VK2NMfFRJiYJANmAbWvtTtvX3lVcpPLoSiuy6cnYso6LGHv6wlETOxK3wsFMYB4A5tVYkcUdO1tp2fPOPWRiQ0k7/32DXLg9127n4LPv+oWJ/WAvF0nc1d1kr0mEEr3NLiLhJXas44NW+NFXy+faCU+t73jyMz04Exkvd5ALTc43E5IGuHA5gwlsA0C8xa6psh57zZYnuSJv34W2bJqISbc+zvdvzxobYwLTGSIwD7gIlxOomD6AeJtVE3cTuWeC+kwgO1nH7xXpJPcn5jOZ9gSt791l9xobK4CPSaLFriEnQM71WVzQ1k/uzwSJQ4P8/mXd9l6DV9m+Zke4mHrJjbaz3t/bM81DBNKB/EXmk3U81zF2fmmWDQZdxi9mxX97/psVmR9ZxNdfqCf/R2NfJWlDzOYat/0zuIK0gZhPZINc+Z0ZXVTtsmvdTTg+S+JM+N9tX5/crywxoxBAosELX3ByX0xHeJ2RbOC5n1ESJ6ZJxEgCcBETJ0s84yJGn2XnHKG0P/91kqq2sYvf8yot+9u9Z5vY+G6X57yy/MYw3Of2TG3HcKDD9j84xK+bqs5vDNxMApig/FiDjY2X5X/OBvuZwQnvf4a8/zLTE2ZGAADB39r8MzrblssG+TMVG7+yw8R0w0X4P3GBNSTw9hPh+DjPBwsvsWYoezfbd5rQQv5O86G5L5vYA69dTMs2VNn3p4awdUk6kuBmPoxbF603se1xMgEu7VrcbEXyl5/blff9mZh+oIE/k1WEpyagbCKFw3ncQ7/JJYQQQgghhBBCCCEKHn3kEkIIIYQQQgghhBAFjz5yCSGEEEIIIYQQQoiCRx+5hBBCCCGEEEIIIUTBo49cQgghhBBCCCGEEKLgmbHuipmwB7ngpHOC18WxLXg0P9cIf4KXy4Tzc1IMH+DuCCPnWtuPbMBeMzjE3SlYu4baSZtcHPfYuFTvse1PRMto/cELbNnqV7nrSoZc4uh7reVONsGXVdNzxJ0xyvrl4ljVzKLEsS7DbWt81kiDOmZ5M7z9QwtsrLwnf4cb/6h1SGnaQOZ/IW8/WwPMSTM2i89fvNW2taLbjnWmljtO1TTZPZBeb+3NKtf20/qpHzea2Kc+96iJPXT4Elp/xx7r+uEhjoUAcCRmbeeunL3LxH50aCWtX9ZqXUvu/+77TOxvPvlDWv/zL11rYqFSazvjbOauP2OL7L5aee5eE9veRzcFci9PvW42JXdFNzLlOXhLJ/eGm7NaLmj3H3O8C5M9BXDHMn8sf9cj5s5Ws8vuaeZC61Y/1panCyAAP3HSY05KzK0NAGLESThEHGfdiF5o90RpBbd8C//BuhPGW8j9t9lyAHdHzFTYs6Zxs9v8ESfHCrJ+8jdComPNrgkAI23EdWqz7aubu2Dfq/asZlkp3MPXWrLWtms6Tor//X3PmdgPnn+HbdMgd4es/4PtV88a29bqFv5cFx+sMbEKF9OoZJqsNeIaGurkY5VoIft6i+1X7Q3WyQsA9uywrpPD7Xb9us0VO8OSLfk5PgJAZPPUDe/lhpfiJFLVfD8w10Fvmjiuuzz7MPzEXD10jD+7psvt/aOLbLmKrvz3M8PNcS9D7l+5z5bb9NMltH7LO63j2+B2/pyUJO9qiYU2p6Qj/JzJBewYlh228zLWwPvKXC9L+21Z5qIIcNdEtn6CUf5MMmTN7VBKHt/LD/P6oSF7JiSrbf/ZGQMAOTL+rE/9y/laz0Ts/SsO2Wu6OfZ5ttv3BLZXll/HnTyf/4MdwJ9f/48m9sFNN9P6zLGQuSgCQEeNfVhqDVnH+c1R6yIMADULbNlvPHu1ib1n5Su0vt9vx/rAsM2Tx/bYmNv9F9fZvbrh4Dxaf+Do1LnKjeVnT6vf5BJCCCGEEEIIIYQQBY8+cgkhhBBCCCGEEEKIgkcfuYQQQgghhBBCCCFEwaOPXEIIIYQQQgghhBCi4JmW8PxXv/pV/M3f/M2U2KJFi7Br13FB52Qyic9+9rN4+OGHkUqlcOWVV+I73/kOGhutiOmbkfMDnhN0xUpdBOZHzrIx35gVnhst5fcZD9vrlnfbct3vsgLbAFDRbcXYEvX222GinqvxMuHXphds/ZG5/HtkeY+tf/gDREyY6+7BP2IFDUfO4mPd9KIVWcxUhkys0mrJAQB619h2BQfs/d1MBnJ+265MmZ3rZIaLNFbtt/dnIu0ersVL6/dcSoQje/lchftsbPA8K57HjAMAIOcngqREfNTVZKHSlj12ji3nSXCRSeeXtSY2tsaq+aeHy2n99Erbr68/fh0ty/C1Jk0s5+fiqSG/vdfTh61IZHgfFy/8byus0OTDh6wg/md++VFa3wkT4WrSVm+ti3HBsG3Xxp3ksMvwuaq5aKqjQjbBBbpnIm9nngGA8gM++IKT50DaapG6UtZjxz/nIryeWzFiYsktVnk8WcfnlAnf91xu148nzet76+waqHrBimZHO/j5w0w6mJi+G0wM2x/jZ6V3gIgPb7MDmw3ywe67iJkEMDF0rpJd1mmvy0TeB5bysQ6TZwhmqOJ3Eb4PDdh7MfHnxiUkqQAY/ze7F+Kz7P0j2/gjYIAYIsStvjkVmHcjXWvnPzDIc/WjD1xuYt4WMqdtxE0GwOEKO39Bsqb8j3KR3BDZg0n+CEhFld32IMOpsPstQ9rf/5M5tL5/lh2XEOmr1yUFJNtsfTYvzHgCAGIn1c8l/zRB8reTtzPXjM7LwRuaPK8ruvjZF2uzZ7pDnn2dMn5Oh3fbtcNE5pnBFQBU77L3qugieY6IhgNAnKzHABE+T1nPLgD8+b/0+l4TSyb4S92RV5pMbHwef6mo2G2fs2IRW44JxANAZrZ9Jh1L23ciJgYPALGFtl3MOIuJ0QPAOHn/YYYGTMwdAEL9dg0On2fb1LKOn9OxVhtn81/mYsbDjLPYWqk4xJ+Th9pt+2OtZEziXPk+QJ4JnGXWjOT51xbS+iDGA1c//SkTq5vFDU7mVlkx9v5E/g+gv+hZbGKHenhOu+H8zSb2RMbW39jHhesz5L16VpXtV3IezxMD3dZka0PCnlVM4B4A5s2degaMx1M4TEtOZdq/yXXeeefhyJEjE/9eeOGFiZ/dfvvteOKJJ/Doo49i/fr16OnpwbXXWpcxIYQQwg3lGSGEEKca5RohhChOpvWbXABQUlKCpib7pXx4eBjf//738e///u+4/PLj/xXugQcewDnnnIMXX3wRF19srTIBIJVKIZWa/E9MIyP2v3YLIYQ4c3ir8wygXCOEEGIqeqcRQojiZNq/ybVnzx60tLRg/vz5uPHGG3Hw4EEAwNatW5HJZLB27dqJsu3t7ZgzZw42bNjger277roLVVVVE/9aW1v/iG4IIYQoFt7qPAMo1wghhJiK3mmEEKI4mdZHrpUrV+LBBx/EU089hXvvvRddXV249NJLEYvF0Nvbi0AggEgkMqVOY2Mjenvt31O/wRe/+EUMDw9P/Dt06NAf1REhhBCFz6nIM4ByjRBCiEn0TiOEEMXLtP5c8aqrrpr43x0dHVi5ciXmzp2LRx55BKWlLsrub0IwGETQRTxWCCHEmcWpyDOAco0QQohJ9E4jhBDFy7Q1uU4kEolg4cKFeP311/Gud70L6XQa0Wh0yn/56Ovro3/v/mZ4M4D3hN8zC/e7WN7RLljHhNE53N1hwb9ad4DDayNv3sD/4tg51nGAOSMFh7m7hS9t62eI4VLKxYXNm7bXvWhBl4lt2cDdIbzEXMrTxq0Yhwata17TBuvE0buKL6vyfTaeI+Z2c56M0vqxs63rxNACO34V3Xys+lfYX1ys3WbLDp/Ff8FxoMPGS3vtuipxcbLsvcg++LB5zfn5+DGH0aouO4HDbdxJhDmsMNcYx8WxMBWx7SrZa51k0nO4Yxmj/nzrDvb/zLEuIADwg72rTIy5KAJAe6TfxF452mJi4+eP0vr/+cRqEwsvttoaiRHb/+M/sOvys6t/ZWIVXu4Oxvju/j8zseoQr79vXduU/59NWRegQuFU5hkAyAYBnLA1fS7Ll7kmZknMzXGu8RF7fg4sZS6AbvfPz0nRm+LnV3bEXpg5HrrB3OVqLrG/0cCc/QAgTpyEsyneWdaucI/dU25jlamwY1XRZevHgvk/AjF3wLL9vL7nzwdNzPecdacd6eCWd8lal46dxMBWPtbp1WRegzZWWsHvn+hkDk/5u+ZlK/K7P8Bdu/J1OM2meP2Ai2vnyUSt4S4AwB+zMeauCQDeFNmDxMk0uoh/NIlstofIyY6Fx9vEn2F9i2xjmy6OmtjePm4P6euy7WL7J+MyJ27nTSFyKnNNSdwDb3ZyDpnjIQB4yZk+XmbHOFXt5uJt187wfFu2JM7bOTyfOIYTdz+39vtH2TrNzy0WABq22rJDxEmxOsyffQajEROLnMfd7RL77Z5oXGdfSvov5nmy/CXbrtE2W3b2z20+AIDey+pNbLyMFqUwJ8rgkB1/FgOAsQYyr922/1Fi7A3wZyXWJv+oW+4gjr+v2wuMzMk/T7M2+YgLIsDfP5O7rQsgIvw9I1htn6vXLt5tYrfUP0/r33v0nSZW4ec5eU2lve6vu+x7fV09SV4AHtm53MRa6qImNkbcPQHA2W2fX8ubj5jYrYvW0/pXL+80sf/1+vUm1hzmGoa///VUJ8hcMr93mj8pO42OjmLv3r1obm7G8uXL4ff7sW7duomfd3Z24uDBg1i1yr6cCiGEEG+G8owQQohTjXKNEEIUD9P6Ta7Pfe5zeN/73oe5c+eip6cHd9xxB3w+H2644QZUVVXh4x//OD7zmc+gpqYGlZWV+Ku/+iusWrXq/+p4JYQQQryB8owQQohTjXKNEEIUL9P6yHX48GHccMMNGBwcRH19PdasWYMXX3wR9fXHf+Xyn/7pn+D1evHBD34QqVQKV155Jb7zne+ckoYLIYQoPpRnhBBCnGqUa4QQoniZ1keuhx9++P/681AohHvuuQf33HPPn9QoIYQQZybKM0IIIU41yjVCCFG8/EnC86eSVI0DX2hSrO7A+7hwHojwdHifFU7zueg7MzHzqv1WOLD3Yn7/koSNpyI2NjqX379lvW1/osFOS2QXv//QQtvXg3vaTCw0zOXXSi8aMDHnl1YgF+Aiv/0r7P1zAS4ymCW6q2PNtv+d/7OS1mdjUNZj75Wo5331D9v6iXobc1srnnFblonkH11BhAvB11UyYoVzc34+fkwkMRuwfa3u5IJ83owVSR+zupfwj3AxX0Zw0I5JuooLF/qIGG/foB2rb2+6mtZPVxGRzAE+12ddt8PE1o8sMLGqSq6+GrqIC9KfzLyaYzS+Y89sE2PC+cMj+auMfmzJ7/Muu6t9qjBuLlG4wvOnmsSCFLylk+vYRwWyAXTbAyw9z55fvhjfPwNL7V4Jd5P8cTkX3swSMXAmEO1GqMfmFSamXdbFcw0TAx9+3gow+7i+NR1XN5F/PxlDPxmWhItwvp8IjzOR90APF3hnuY6JzPu4RixGOmtMLEcEid1gIuMs12UDfK78MTbXdkzHavlaDRExdXb/Yx18/dVusdeNLrIxJuYP8LUaIrkmTvrkdl1fpV1sTHQdcJtXPtbMaMLtugy238t+x5+BGPEuuzGPBqx4s1ub2FgFBvN/BjhZeD9L1o4AfAkPfCcIzw8u4eWc2TZXh4nAOTMNAgBf2u5JPynrZtqRrrb1vRl7ng4v4s+pTRtsPF1ODJpc2n+s3cbricj8ISIaDwDBZVZ4O/UcL5sjj199V9i9U9LPB4sJt3sytv2vfYG/E4R3k/cPkhPj9nESADcOC0ZZufxNQ2p22fkf6OBzFba+UdTQwOdy/0SZvW70bPv+0LSBi6l3zbZi6Gxd+7q4QRR7p2LC+V5iJAUA4+U2T/3ipQ4TezKxjNYPz7Nnf7ybO3x86M+tIVdF2CaquVX8nSSWsAYn723ZbusH7DcBAPjS8PtNbOvr9sPGgWH77AMA/2f43Sb20Krv07KMvRdO3cPj8RT25VGveGxRhBBCCCGEEEIIIcQZiz5yCSGEEEIIIYQQQoiCRx+5hBBCCCGEEEIIIUTBo49cQgghhBBCCCGEEKLgmbHC8+WHAd8JAnL+Ed7UsSYrklf/ilWOy7kItDLhb1/GiuS5Cb9H221ZLxEerN3GhfdG5tl+lfdYIdCcn98/0WzbH9prBebS7VxN3bfeCjJWHeVisMfOsfdq2GLHmvUJAEbOIoKYROR8vJSPFRvrkjE7LpHXaHUqSOiP22uGXfqfqLdtHVxqBSWZmCHAxR/ZWhsP87mu3W4FSccabad6V3GRxfKDNsb677bWKg/Y+WMi/2xOACD4shVPZWOVquVixkwQ0mN1vwEA//76ChOb2zhoYgf6uMlChJQ9PBgxseEEF/P1+G0fQsQkY/iI3asAH5cfPn65idVeRJQ/AYRKpyqSZh0yeAIAEN4ThC84OQ9MjB3gAs3TESNnwu05Mv3eLVx02iHnl9Ni11Soh6+pfMW0QwO8/0mi3etL2/r+GK9f8ULYxDIu+tqsrWysKrpchMfJWIe67AUCXM8W8QsTNrjLtp+JjgNALmj3f3CAmIwQgXw34i12rN3an2ixazXcY+/vTfFczfYAE7lnfQL4WgHIWLmYPIQGiHA+Wysu9ZmhgLfHzp8bXpc9zGBC0SeLsbuVA4AMMZRgjxB0TQIo22z7NRazeS3dxjvlG7BjxQwxYm18rYdO0inOTmPszmTchNfHD9vnt3CfPU+YmDsAJGv+tN9dyEWIacFhe3ZWdPH7DHTYdVK9i60dl/6X2bKH9zSY2HtXvkLr/3Lj+SYWJs+5ABBbaPNn3W/tfhiZT6sjPYts6rQdl/IIf/9Kl9l7JYiZTd1Gl3Pa6q7TZ8eyXt7/8TLb1ngTmxdev/KA7f/geXatxFr5XLf81p5pfSvtebb7Jn52l5Jzyk+E75nxAgBkiPEAW3+BIZc9NWSf/z2k/niDy+E/Db598AoTe9esXSb20lArrb+2bbeJ7Ypb46DvbVtD65/d3G9jFVak/pmnL6D1s/V2Xd+04eMmdv6cQ7R+R03PlP+fDmSwkZacin6TSwghhBBCCCGEEEIUPPrIJYQQQgghhBBCCCEKHn3kEkIIIYQQQgghhBAFjz5yCSGEEEIIIYQQQoiCRx+5hBBCCCGEEEIIIUTBM2PdFTNhD3LBSUcE5gIHAKWvWteEoYXWXsKtPnPSGybugG71A8PESeMgL8sIDtuyQwvs/eOt3HGuZMzW9w9zJwnG6CLrpJKp5MvCP2JjiQZbdmgJdzzyhG285THrzjTQwe/PXL9KuOEQxUfcDRn9y7ljlH/Ejit193zJ5bor7Lqsec2OSbKOf3seWmRdd5jjYPgIv/+xJbb/FfvsvWp3csvCfPcF95HhZVOR/Ndq5V6y15fwtp5Xc8zEOqq6Tay0hLsOfrhps4l9d/zPTOx/n/UrWv+vf/LfTazPb504fa18Aa+YfdjEXj48215zu3UdAoC55091Ihn3pWC9VQQAjJc7yIUm12ZogK/JcLdd/9EOu/58MX5+RDptLFln78VcYAEgVWfPCuYi51afORYyd77BDl4/NJjfXj3WwXPVdKjaZccwMSv/vOqPEdclkr/cCG2zbk5sXMt63MbEtp85PmYq+Fj5yX9/ZGUzFTxXOAHyXED6H78wf8c95m7o5u6YrCO5psuO1XCQ53rm5JetsOvfE+P1mbvhyS6AABB16X9owDqEjXTwsmwPlvXY9rvtC+ZQmeUGqRTmBJlpIXsl5fJcQ/YKGxfmTgoAsbap85Ib489/Yio5skcB7rqYJi56rtdljtXV9l7BIX52sXkucXn/YbDrHl1OXLzDLo7PAbtPvFHbqV93LaTVnTKbk+OzeVL0ZOz5yc75bJt1NgeA1rqoiY38otnEhgPchTtE3Imrdti+JhppdeoEyMZ/oIPPtZeZQ1aTd5qt/P69F9m1wlxk3ZxlBxfzcTkZf5TnucRCe06xtdL6DD+Tjp1jy1YcsmM6uIS3KxC14zoesesv0M3XX7Lfxj0u58IF1dZ18M7GbSb2P1P2PQMA7m5eb+sfvcjEvr7icVr/q3+42sS6h+29PAtHaf3PL37WxP7Py+82sa2vz6X1l599YMr/z6Tyc6zUb3IJIYQQQgghhBBCiIJHH7mEEEIIIYQQQgghRMGjj1xCCCGEEEIIIYQQouDRRy4hhBBCCCGEEEIIUfDMWOH5yoPjKPFPCrglI1w0c6yeCPftZ2LybvXtEJQeJSKJRMwRABq2WPFEJnzP2nT8urb9mUp7/8guLhzIhNdDUSt811tlRcsBIPI6DVNG5xCR8SYba3qBfzsdbbFj3U8EKYOD+beJzb+bSUB0pRWqO+v7VmQxFOUigZU7h0ys/5JaE0uQNgFA1V57r0S9HSs3gWQm0j463851/Ua+1muISUPOb8eqd5WLQO2wjYXJXgkO8PlPRWyMrd/EfBfjgveQBvRykcX9x2pMbMfOVhM771wr5ggAX336QyYWIv36dsnltH6mkvQhYdf/Vy59gta/49lrTYwJFK+4gqiZAzgUi0z5/+PjEgN2IxsAHBex9hNhwtuRbXZOmWj28Ti7NxEIJ0LQQP5i7G4ir/mKWeeCXCA7cEnUxJyn7PkXJqLrAFDWbdsan8X7ysaQjUumwkUQmcTji+zAMNFwgAuXM5iYPAB4OuwhXvYUK8zHqrLLtj/anv9/kwztt+syR+Y/stlNTNzeP3CJTczZ5+z8A3z8mJh5WSe/f6LFnleVnbZPTOAeAJItNi+W9ZCxdhFjT9bZGBPjB7ghQLzFXjfM7g8XoWsSyxExfCD/vYJZ/GAIkHENkXXhZvzgTZ20LtP6b+eM6t1ZlPgn1/Wxdr4e0hE7zuNl+RuUMDHyMutjg1Q1r1/aTwyCqu39w31uYvRMZN7u5+qX+etn7XZrXXT0ArsehyMuZzcRHmdi/gCQ89u1OkTeExqf5Hvv6HwrMu8ts+XCu/N3khhrIAZbLu1nc125z5YL2lcXAEBglJxdTXZMYvbRGQDgj9sYaz9rJwCE+u292Lu2W/+D2+24hvtsnw5cx59pwsSNKdFo21RC+gnwZy1mZpCu5wZZ71y6y8R+u/dsWvaZ7nYT+889S03sNiLwDgDnr7/FxJx+O367V/CPAqm43W/+iN2rbvf//r7VNH4yn1jxGxrfHOWC9G+GspEQQgghhBBCCCGEKHj0kUsIIYQQQgghhBBCFDz6yCWEEEIIIYQQQgghCh595BJCCCGEEEIIIYQQBc+MFZ7vvcQLb2jyG1zTi1w4buQs+51uoMPG5j88QOsz4XAmfDdyFhfOS0VsYa/Vop+WcH6qzorUhY/w+uNhGxuYQ8T0j9DqVEzeP+Ii8kcE4csP2thgB78Xa0O6Kv/7AzZe3mPXRSbM61e8bEX2Bhfb+2cDvP7wPKtGmy215XxWi+94WWYyQARF2fpxizOR+WNL+Fpl6zowbO8/3sQFamu32Qv0vds2quYFLgj6qc89amI/uP0DJhaM8mMpeo7dq9UHaFGMrLFt8CWIyGiSTKALyTq71vqfmk3L1kbtHIwQPcmHDl9C6/uq7LiWtUZNbMdjVowSAMaWTV2EuUSSlhNAtjwLp3RSGDddwddfss0KZ3titmz9Zv7fjti5yASimWg2AMx5R4+JHY1blVs3MfD4hcTloduufyMk/V+kf2+vmySi16FBfn4OXmUPxqyL8Heoy57VTGQ+W8ENFfw9dl4Wzukzsf09Loq6eZKq4/f3dlmReX9F/sL5Ry+0Z40/ZufFTXw6Q4TbmXGFz0UPmQnqRvdHTMzbwtufrbMXYHOa7CBrEgCIyDoTmXczadh00z+b2MU9n7VtIusEADLttl0VL5CHLQCJWUQ8OUjEt13GOtxNzgAifM/mD+BzxYT7QwF+rvhjxKShxbapootWR3QRj4up9F849Z0m0ukm3E7eCapt2bptvP5YDatvY0zgHgBqdtmzp/QYMZIg716AiyB9wF4z5/Kcffhyu89yxKAl0M0Pv+CQvW6JixkVM/6q2GivO8Qfs+Ale4+JsTPTJTeYSYAvzdvvIyYPI/OJGRQZE4CvCyYcH4jy+qFjdl7HGtj452fkAgBV+8hz9sUu/Y/b/o+SZxJPnJ/zEWIGNnKDNY3xborQ+qNt9pxt/o3ta7yJO9dt2r/ExDwu+xJVdmGlhqyh3MaR+bR6NanP/AheXb+A1g+TOUwS84d78A5a/x2z95pYvM7Wv+/376T1yxumtj+bsM/jDP0mlxBCCCGEEEIIIYQoePSRSwghhBBCCCGEEEIUPPrIJYQQQgghhBBCCCEKHn3kEkIIIYQQQgghhBAFjz5yCSGEEEIIIYQQQoiCZ8a6K1bt9sB3gvtG1YuHaLnYrLl5Xa/7XcSuBkBFt3VHGJ5nXWwiu/h1/QnrzhDZad0Zjq6oovWZO9/cJ6y7woFruTNOead1bQgN2PqpCHe3YO6IoSh3jBpaYMclRpw8QgP822n1busY50vbJZixhmH/Vdbea7Ql/++0fuKwEj5q56/7cu5uUfuS7b/3qC137N3cyW7siLVXKu0lTji1/P5122xbey+29Vt+y51IhxbYsY63krLD3AmEOSmysswxEgD+v7uuM7HcLFtu8AK+/pi71MgaPta5jF0Xda/advWhgdb3NlvnjvZZvSZ2ZL51UQOAaGeNiVUtOmZiXTtaaP2P/NnvTewXD64xsVSzm0OTyJfAMR+8ocm1xdylAKCvgjh2EnclN3fZii67/mLECahsP0/Le2PWCZA5GYaIWxoABIi7WpC0abid779MBXH3I+6GSbg4Jm7j7nSM+DzbVl+MuAOSGACEiJnynh32sAm7uPMx10NvijjhujhRsnXBCLTFaNz/u0pyL1suMctt/9t2sTFh6w/g7ffW2QZEnnVxp+20e4U5BqaIiyIAVHTZec2Som7ulBffb50UWZ/YOgOAMrJW3faFQ5zf2B5OuuR1NgfMnTKymY8VWwOsTWni+AkA+HOyBrfZ9efGyePqyXPtn2mEezzwBSfPkNAQX0+panamkdzRmr9jHcPNMY89v5Udsc9+6eVu7oY2Vs0cC1dydzTmwlq5z5Ybnc3bzxxnS4jjIcCdEIeW2TMhcJTn5NL+/J6/xl3eaUr7iRMfMex2cydkZxq7JnNMBABvOj8nxPBqkjwA9O+vJlF7L+aCCAAVh+yz1vB8W7bcxdk1ttCuy2C1fSdI9/Nnj4pP2O8KgwP22Z0/ZQCVu+1PomfZcmOzXHKH3/aftR8ABo7a87tit33/Wp85l9Yvm2XP+bOb+03sso7dtD5zPaybNWxiA938W0e82W7MF39p3SXLl0Vp/ZB/6r7M+nnuPhn9JpcQQgghhBBCCCGEKHj0kUsIIYQQQgghhBBCFDz6yCWEEEIIIYQQQgghCh595BJCCCGEEEIIIYQQBc+MFZ4v6xlHyQnCYq//Qy0tF7L6zFRgPMe1tJEus9/5qvfkJ2gGAP5RKyh3eG0k7/szkfiReXZaKrdz4cExIjxd3mNjbmLgTOS7spMvi7EmK5LX8lsicFrGRQ6Pnm8HoSRhy3mJvjkA1G63gnzd77TCt3Xb+PwNk3FlYvo1rVxkMbXPKueWHrV9rarkKpfHEvb+2WG7/ir30uq0rdkqO1j9y/n8OYtGbbDXCjL6m8ikAEiPWEFQ/5hdV+Mu+tKZSls2WWfXVOkR3n4PmdZdlz1Ay7b/yy0mNkIEIbNVXBCSCervPjTPxDKVLvXJdY8diphYzXwrRg8AT92/2sR8RNBzvJTvtdmPTG3/eCaLA7SkCA5OFQTGx/poOd/WRhPzE+HySDefk2g7MekgwvFuNG629Y+ssfvHl+IyqdlOK1yaIfrSbmLqTNDXQ4Rr3fqU7LDnSs5FeDwwaPsQGrDXTbtoaUc7yGERtHsywX0fEO6x92ci52z+ASBVx84FO65ugrbxlvwEjZnwP8DHL7bGjr+bGYCPaELHAzbXJuvyF3/m48fXWrKOiLGTa+aC3CSiqpvMH1nrbiYPjMi8KI1nn7PPpkwkH7PGaH1flx1XX4/tLF3TAF3Xnpjtl9u+9HfZgWFjNbiCr7WTnxezxKBBHH8v8WUm13XPn/FxClktaMpoG5+PyHa7p5gYvBuJRls/0WgXdLaM33+8jOw9IrxesZ2f/fHZdk8HiPGXm5g7w+8i3B5bbA+6qpd5uxisDcEhYkTRze9fcciOYe/FdvyZQDsAJGtsWSYyn23jYuYl2+3ZE+4jueciWh2BBpJTXrBJ2e39t/9i2y9vtT0nk6P8nF60oMfEOvfYpN66gG+q/URkPtNtJ9UtTw8vs+snWEbcAFyE770Je+VfX3UvLXvpuk+bGBPeZ9cEgLGEXde7u63LwW4Q5wMw6wsuMv/eC7bR+k8/e4GJsVlN7OemJ/7OqS3IpvmaPhn9JpcQQgghhBBCCCGEKHj0kUsIIYQQQgghhBBCFDz6yCWEEEIIIYQQQgghCh595BJCCCGEEEIIIYQQBc+MFZ73ZXLwOZOidGXPc5XBkkR+Aq1VXUQMDkBg0IrcxeeWm9jhy/n3wLJDdgiZGHm4n4uGpqqJmLjfSryNzuX9zJXYeO9lVsyw9CBvv3/E3t9NOLxin70GE5k/uob3de5/2tjQQqtIWL2bK89nyu1YM5H58h1Haf2cv8HEBjpsnzw/5SYHuXobi7fYuXI2WYF6ACgnurOVa3tN7EidbScAeDPEZKCTjJ+LcYJ3gxUePHCtXStOF99rTDsy12rF/8ZdBFF92+2+YmsqGOVr/dgSG5//q4/TsiVEpNg/bOeq6Tku0jjUTkSuq+z9q1/l9ZmhQvZDgyY2PMLHOkdEykFMBuqeIx0FMLTgZDHgGXvUn3bSFYDvhK3Rc6SalgsRQWUm0O0mxl3RZefUl7KxaDtvZ8/lVqQ11GPn1R/j+6dqn92XfRfZ9Rtoi9H66S4rKNu80J61R0AOSgBhInKeaHExbiDkK0YOcEFxH9kDbsL17LphIh7sJgbO7h+fZ8t6evj+r+piJh22XO02fv6wNciE493G31tHFna3re8fodXRvMMmu9f/BxHeJwLrAFDRZWNM+NxXyZ/rhtuJSQoRuXczDmAi+S5Lja7LCBHKBlwerAhsXpiZAACEBuxaY21ifQKA3Aq73/2/s+K/biL9J5sk5JL5PZOfaQSjOZT4J8/w+q0uBh1WC5sKtze8yOv70iSnnEXE5BeSPY78hdcrd/P1GGuzeaqqkxgUuZhhOX7b/mPt9l4l3N8JyTbbr0yU9ym828a9ZPxGLuUi13VP2vqDS2y/GrZy4fgceddjIvU1P99J6/d+5FwT8xIzmMp1IVp/YKV9pkxHSO4kouUAF2lffN1uE3vpD8T1CUCw386rl+UZl7neG51jYp4yO9aH9/B3qrJZ9uwbb7DrJxHh78+hLrJ+MjZWztMUFY6/7Ef/m5Zl/fJW2wuX7+Aq/8NhO69sB5Z3uRgXkQR4znusS9rGvrm0fgkxf5j7TmuH1fMLXj910mN5vgYn+k0uIYQQQgghhBBCCFHw6COXEEIIIYQQQgghhCh49JFLCCGEEEIIIYQQQhQ8+sglhBBCCCGEEEIIIQqeaX/k6u7uxkc/+lHU1taitLQUS5YswZYtWyZ+7jgOvvKVr6C5uRmlpaVYu3Yt9uzZ85Y2WgghRPGiPCOEEOJUo1wjhBDFybQst4aGhrB69WpcdtllePLJJ1FfX489e/agunpS9v4b3/gGvvWtb+Ghhx5CW1sbvvzlL+PKK6/Ezp07EQpxhwdGKlKCrH+yeV5uuEfd7ar3WGea4TYXbxwST0XsNSv28epjzcxJhrhwZbhjAYPdf7yJO6GE9lonh2yrtXbzjHPHBeZ4kCEucgCQtaYXGFlkx5o5/gHA0fPJ/YkL3YFraXWE99nrOmQFH7qauxv6iLsec0Eaq+euDWwNMidANn8AEG+17hjxTuv6Udrr4uRxyYCJVayrMrGReXxbj5xFXD+Ju6EbbKxze+2env9D6xgJAK99nriOvGAv6jb+2SrrTubzc9ea0iP2GiOLmBOa2xHIHLOIuxpzQQR3jcSv7bqcu53v69hse69UxI7f8HtGaX1P51TXm2wBOV69nXkGAJyAg1xwcnwCLo5vJ5Z5gzQ560N2mwLgjnfM8Sw0wNd/mjiuZSpsXnFzd4wusmWZu1xyGo5/Q23WMa7CxZ2HOb5V7eJlM9bcjboTIsjdATNpO4eJFn5WMJgTX6zNllu4oIfW340WE6vsJI6LLXxfJmaRs5q4brnN9UiHPVeYExRiLnNF1lWEzP9wOx//xCy7B2t/Z8sd6+BzEm+x92dOom3/7+u0/v7v2vFnjoFu7pq+RdZ1a6jH5loA8FTYPgwS1+ZsBXfijGyz/QoGbP/d3BHZGmL72u1c8hHX1Fhb/k6mueDU/udy+e+z083bmWvGwx44gcl5SdbwZ6+xBjv2leT9gzlAA/yZPkceyUv6+YSmIjbGnn3dHO/qt9rY8HyS+xYRu3EATtqOS3KWXVOeDB8/1q/sMu4YnBqy8zc2y1438ls+z0PECZm5I/Zcxe31At1sDuz8H7jlPFo/HbFlmevkKHmeBIBQt10YuQBxZiUuigB3cnzlYKuJ+eIuc7UsamL+p/k5yxiPkDM1YNcKc9EEgAR50GDunoEob/94GStLnt2r+dldErVnvzObO3lWbrQv4MPLbLvYXgcAX7kdq+B2e03m+AgAFbvthXc8s9DEyg+7uPjOt/FDz1gnxfBlPFGNvFI79Xq+/N5ppvWR6+/+7u/Q2tqKBx54YCLW1jb55Oc4Dr75zW/iS1/6Eq655hoAwA9/+EM0Njbi8ccfx0c+8pHp3E4IIcQZhvKMEEKIU41yjRBCFC/T+nPFn/3sZ1ixYgWuu+46NDQ0YNmyZfje97438fOuri709vZi7dq1E7GqqiqsXLkSGzZsoNdMpVIYGRmZ8k8IIcSZyanIM4ByjRBCiEn0TiOEEMXLtD5y7du3D/feey8WLFiAp59+Grfccgs+9alP4aGHHgIA9PYe/zOlxsbGKfUaGxsnfnYyd911F6qqqib+tbbaX3UUQghxZnAq8gygXCOEEGISvdMIIUTxMq2PXLlcDhdccAHuvPNOLFu2DDfffDP+4i/+Avfdd98f3YAvfvGLGB4envh36NChP/paQgghCptTkWcA5RohhBCT6J1GCCGKl2lpcjU3N+Pcc8+dEjvnnHPwk5/8BADQ1NQEAOjr60Nzc/NEmb6+Ppx//vn0msFgEMGgFYUbmeODLzgpvtm00UWk8Bqrslf6ghXJi80iqulwEaMmwnO1G/lQxUtI2R32mqlqLvA6MpcIlJbaa9Y95yKGTNqaGSm3MSLkCwAe0n0mXAkAVXutoN/wWXZcqva7iNHW275myuy93ITrmcg7E9mreY1/u40RQclQ1LbV6yJoyQTRjy2xbSo7xMfPISLppUfs+LkJ/zeVWkHCA1fUmBhbEwAQIML7TPifCeQDgHecGSJYQc3dn2g0MQCofsnWP7qSGBfs43vNP2jjJQf5WmHrPThg9+DYIi787h2w180GiCApMS4AgCTxPmD7Z2gh39fZgB2r8FEiqPlTK/wNAH0rp64BJiY6UzkVeQZwzzUnwwS+ASDaYQ/L2i12TQ2u4Oefr5KLz55MEjxXlXW+edsBd4Ho0KDtFyvrTGOtONvsRmMC8273il7I91/lNttXJjweiLnkZSLG7RDhb9+Ay2AR2Pj1/2QOL0z65Sci7z6XJZEhYuaArZ91WxIpW5YZJ7jB1povbeuzM9WNDBF5dzMpYP1i6+fgXxDlZwBjMTv+yTa7L93aPzZgz1UPEVl2g82rn6xfgIu8l/Wwe/H7c/MKUs7lGTBDrusnOt0VA3z9HOvg1y0E3s53muE2L3zByWeIqn38Ocv/7mM2uK/WhMoO0+p0PbH8X9HFn3NHV9p3rbonbX/S5Xw9Hl1uY47f7r3mn/LDa6DDXpcJnDPRb4C/v/g3cocJdvrHZ9t5yZHnMQAo7bcxLzkn3YTPmXg/E/53yxORThtLkMfv4BAfq3Hy/hW8aNDEojvs+gOAbJkdK99hK9LPygHAR8/ebGI/9i8zsaFhLnzvGbIz6CNi7m7GA7m4rV9XT0xHXO7P9kXfpfY5I3CUn/3M0MHbyZ//qCFE1L6nBF2E20f3V5sYMy4I7+fvVEw8n+01N5MDZqjA1v/oJm4cl2mYeobkxvIzOJnWb3KtXr0anZ1Td9Xu3bsxd+5xhfy2tjY0NTVh3bp1Ez8fGRnBxo0bsWrVquncSgghxBmI8owQQohTjXKNEEIUL9P6Ta7bb78dl1xyCe688058+MMfxqZNm3D//ffj/vvvBwB4PB7cdttt+PrXv44FCxZM2O22tLTg/e9//6lovxBCiCJCeUYIIcSpRrlGCCGKl2l95Lrwwgvx2GOP4Ytf/CK+9rWvoa2tDd/85jdx4403TpT567/+a8Tjcdx8882IRqNYs2YNnnrqKYRC9lcYhRBCiBNRnhFCCHGqUa4RQojiZVofuQDg6quvxtVXX+36c4/Hg6997Wv42te+9ic1TAghxJmJ8owQQohTjXKNEEIUJ9P+yPV24U848I1PCpUNLeL/1WT811akbe+HrCDZ7GeJwjoAXzo/4dSqLq78F223Im2JBjusTCAdAGp32nZlyqxUWqqKi7kNXWDre4jAeWgvFz5kYu7JOhdByQtszNc6amIxInwPcOHs0bm2XKaSCzenRuxcBQeIGDAR8wcA/7CNDS2YhnAuEYRnYvJxF8fo6lftvTzvsSKB47/mwnu962abGJtVN+H68bOscH3JYruufRk+JoHNbF6tcGOOmDEAwMKPWpXMV9YtMrGUi3C1nwjnl/Xwsmy/MeOAwEEuPJ0mY8iEe31c4xHJOrsu6rbZ2GAHH2u2VnsvI/siw/dq0wtT90A2A8jjiZMNAM4JyyB1+Qgtx+RAa2+ImtixHbP4jbrtFZigbEUXr574c9uubKcV1PXH8hfI5vuHPxYw4X0mxu0m5u0lGvP+GM9LMSIS7k0R4xKuJ8zHYBbZP7O4oU1osxUeZ21y5vHzJ7LZ9mtwRX7jB3DxfyrSTwTm3a4772J7Aux/kSerZK29f3ye7X9gkN8/XWvLZqYhvM/MHxLt+a0JAGhpHjKxY11N/GYEZigRb/nThOenYwjBjBNqt/H6I222fo5sKyZQD/C5aplnE9vAVm4oY+YgPS2p3zOGYBTwnTAvoWP8OTfzQ2smFG+ycxx5nahWA8gF7MNPzs/E3Pl6CG63eSpdbsumqvl+qHnVxkZn2zURPYtWR7re9stXbs9Op5/nDm+U7CciJu9GzQIr/J86zJ/JS+L5jQsT+AaA1GL7TB5+yY4/E/0GgNhCOy4Vu+38u80VE++P77HrDy5mNJHtZF4XE4Otbp4nHnz0XSbGxMhzJPcCgLfaHrTNC6K0LONwf4OJRfutyH7ORTg//kH7TObptg8l6Xr+/QEBe92ql/m6Zu80aaslj0EiMA8AgQbrMubstu90Y+w5CXysy35rv8uw+QeAcmIyw8T0M4v4M1nDSSL/2bQnr3caZSMhhBBCCCGEEEIIUfDoI5cQQgghhBBCCCGEKHj0kUsIIYQQQgghhBBCFDz6yCWEEEIIIYQQQgghCh595BJCCCGEEEIIIYQQBc+MdVcsSQC+EwwJRudwd4jm31vHoar9VsV/eB7v6shi6+QR3kccExu5PWLNq7ZdqQhx92jljgM5v21rtN06WVTs4/0v77TtGmuy9/JxwwJ4iUGLn5uLYWyOdV2ofL7MxEoS3IljtMV+Uw0Sd7rSI3yuKrrt/Y+dY8fPzd2POZmUbbJOJslLrGMkAHg7bV89GdunskP82zEbl6O9VSbWRFwoAWD4LHtdNq9u/a/5lXXCyPltbHwOrY5Mpb1u/fl9JtY3aPsEAJu2LDSx2VvtnPau4k4s2VJ7/3A/dy3peQdbQ7Y+c+cEAN+YjVcesPNS+TqxggGQDViHlbIDdmNV1vOxYq4jnoQdFyfMnVBGTnIYzbq4kAnL2IB11gOAyk67pg5WWMtNp4WvyWyFdacJdVonnXgLb1fNI9YJ58gauyazAT7XzMUtas1NwfYJwJ300i3ERs7FXTEQszHmuAgAuaDtA3NMdMtVzF0Ou+y85oIuTq4xHj+Zsv08V8XabH1WlrkYAkAOdl7rf2ft+ZizHsDd/XYH7MJq2EWr4+iF9v5s/t2cPL0p21c2/8xFEOBOnoxsgJ9/o09bJ8Wabtun4fl8rzCHaTd3wmyFbUOoJ7/+A0CaOIRWdNn7J7nBG5JtdhNVPsusHPlcRXbZeT2SrjexKuJ4CVjX4WwqfxfKMwl/3IEvM7mGji7l7xQVh4g7+jEbG5nj8k6z0K5HD3Fhrurk85RssPfyx+0+cXNhY+80yVn2RYO5AAJAqJu4Qwbyf1V1c7Jn+GfZ57fRTWSj2Ud/AEB8tj0TSsgjYYA4PgIAovb9I0PulW2z7y4AUB62ez911D5TVp4/SOuPvGKdBBcstZ51Xb/nLwXjZbZfzHF+vIyfs17iAsz6z5z9AKB8ox2/oxEbYy6SABCM2/vXrz5iYj0DEVqfXrOfrP82l3xGnGjdXFOPXGL3QI48/3vJewIAZLvs82OA9L9hK62OZLV9V/QRh1bWfwCILbZr1RO3fVrY3E/r71k+1Qk6lwTwH7ToFPTmI4QQQgghhBBCCCEKHn3kEkIIIYQQQgghhBAFjz5yCSGEEEIIIYQQQoiCZ8ZpcjnO8b/xzGam/g2y29/5j4/bv/Mcz9i/Cc0SjQgAyI3Zv3/NpuzfuWYzXCcp69h2sbbmki71yd8k58bs37m6aerkyGXZvdzqZ8nf1GZL+FjTsUrbcfXwP5/OW6vB4X+SjPEMmZcU0eRyGWsk7Fqhc5Xgf/+OJLlXIP+5YmOdG7N/q50l69f1ukTTZlprjfypetal+4zxuG2A2/ixdT1O9lWOjDMAOGRdjWf437rnkvkdbW5rku0rdgaMj/O+ZlNWGGI8S9Zf2q0+Oxfs/R0P18U4+QzLpo7f543zVUyORS45dQ5yJW5jatdUlkjfsD19/Afs/CLnh8sU0b1C9hTTeTh+L5aX8l8P7FzPjdkg69PxuI2xPe3WLtZ+r1t9dn8yV277IUv7yvIqP6vybb/b+OfIAZQl8+qaU2n7Sa5Ju7Sf9DWXzP/+bA2z+Xftv8sezBe2V9n+mY5W4XTaSs8KF/05ti7p+nNr1xjLK6yvLnNFn0vY+nN7Ljn5/yvXnMjEO006v3caNne8nNtzuq3vGSfvKW716dll90luzC1PkufkPN+zACBLHt0c9qDqgkP0x1yficmzqoc8u7nBrptL5vdO6HpN9k7n8kydJQf9yc8zAJAl7z5uZekzPSkHuD2n2rl2ex5nc8Vw7T+5P80zPrdnElt/Ou80bPzfOP+m1CdnNAD6rDbu8v7LxpA+a7q8P4Hsd9p/8p4N8OcPsO8Hbt8qyBh4xkieJuMPkOf0ZH55xuPMsEx0+PBhtLa2vnlBIYQQ0+LQoUOYPXv26W7GjEC5RgghTg3KNcdRnhFCiFPDm+WZGfeRK5fLoaenBxUVFYjFYmhtbcWhQ4dQWWldrAqRkZGRousTUJz9KsY+AcXZr2LsE/DW9ctxHMRiMbS0tMDr1V+pA5O5xnEczJkzR2unACjGPgHF2S/1qXB4K/ulXDMVvdMUHsXYJ6A4+1WMfQKKs1+nI8/MuD9X9Hq9E1/lPJ7jv0pXWVlZNJP8BsXYJ6A4+1WMfQKKs1/F2CfgrelXVZW1lj6TeSPXjIyMANDaKSSKsU9AcfZLfSoc3qp+KddMoneawqUY+wQUZ7+KsU9Acfbr7cwz+s8sQgghhBBCCCGEEKLg0UcuIYQQQgghhBBCCFHwzOiPXMFgEHfccQeCweDpbspbRjH2CSjOfhVjn4Di7Fcx9gko3n7NJIp1jIuxX8XYJ6A4+6U+FQ7F2q+ZRjGOs/pUOBRjv4qxT0Bx9ut09GnGCc8LIYQQQgghhBBCCDFdZvRvcgkhhBBCCCGEEEIIkQ/6yCWEEEIIIYQQQgghCh595BJCCCGEEEIIIYQQBY8+cgkhhBBCCCGEEEKIgkcfuYQQQgghhBBCCCFEwTOjP3Ldc889mDdvHkKhEFauXIlNmzad7iblzW9+8xu8733vQ0tLCzweDx5//PEpP3ccB1/5ylfQ3NyM0tJSrF27Fnv27Dk9jc2Tu+66CxdeeCEqKirQ0NCA97///ejs7JxSJplM4tZbb0VtbS3Ky8vxwQ9+EH19faepxflx7733oqOjA5WVlaisrMSqVavw5JNPTvy8EPt0MnfffTc8Hg9uu+22iVih9eurX/0qPB7PlH/t7e0TPy+0/pxId3c3PvrRj6K2thalpaVYsmQJtmzZMvHzQjwvCgXlmZmF8kzh9OlkiiHPAMWba5RnTh+FnGcA5ZpC2evKM4XTL+WZU39WzNiPXP/xH/+Bz3zmM7jjjjvw0ksvYenSpbjyyivR399/upuWF/F4HEuXLsU999xDf/6Nb3wD3/rWt3Dfffdh48aNKCsrw5VXXolkMvk2tzR/1q9fj1tvvRUvvvginnnmGWQyGbz73e9GPB6fKHP77bfjiSeewKOPPor169ejp6cH11577Wls9Zsze/Zs3H333di6dSu2bNmCyy+/HNdccw127NgBoDD7dCKbN2/Gd7/7XXR0dEyJF2K/zjvvPBw5cmTi3wsvvDDxs0LsDwAMDQ1h9erV8Pv9ePLJJ7Fz5078wz/8A6qrqyfKFOJ5UQgoz8w8lGcKp08nUkx5Bii+XKM8c/oo9DwDKNcUyl5XnimsfinPnOKzwpmhXHTRRc6tt9468f+z2azT0tLi3HXXXaexVX8cAJzHHnts4v/ncjmnqanJ+fu///uJWDQadYLBoPOjH/3oNLTwj6O/v98B4Kxfv95xnON98Pv9zqOPPjpR5rXXXnMAOBs2bDhdzfyjqK6udv7lX/6l4PsUi8WcBQsWOM8884zzjne8w/n0pz/tOE5hztUdd9zhLF26lP6sEPvzBp///OedNWvWuP68WM6LmYjyzMxHeWbm96mY8ozjFGeuUZ45fRRTnnEc5ZqZvtdPRnlmZqI8c5xTeVbMyN/kSqfT2Lp1K9auXTsR83q9WLt2LTZs2HAaW/bW0NXVhd7e3in9q6qqwsqVKwuqf8PDwwCAmpoaAMDWrVuRyWSm9Ku9vR1z5swpmH5ls1k8/PDDiMfjWLVqVcH36dZbb8V73/veKe0HCneu9uzZg5aWFsyfPx833ngjDh48CKBw+wMAP/vZz7BixQpcd911aGhowLJly/C9731v4ufFcl7MNJRnCgPlmZnfp2LLM0Dx5RrlmdNDsecZoHjWTrHlGuWZmd8v5ZlTe1bMyI9cAwMDyGazaGxsnBJvbGxEb2/vaWrVW8cbfSjk/uVyOdx2221YvXo1Fi9eDOB4vwKBACKRyJSyhdCvV199FeXl5QgGg/jEJz6Bxx57DOeee25B9+nhhx/GSy+9hLvuusv8rBD7tXLlSjz44IN46qmncO+996KrqwuXXnopYrFYQfbnDfbt24d7770XCxYswNNPP41bbrkFn/rUp/DQQw8BKI7zYiaiPDPzUZ6Z+X0qtjwDFGeuUZ45PRR7ngGKY+0UU65RnjnOTO+X8swkp6pfJW/5FcUZwa233ort27dP+fvhQmbRokV45ZVXMDw8jB//+Me46aabsH79+tPdrD+aQ4cO4dOf/jSeeeYZhEKh092ct4Srrrpq4n93dHRg5cqVmDt3Lh555BGUlpaexpb9aeRyOaxYsQJ33nknAGDZsmXYvn077rvvPtx0002nuXVCnD6UZ2Y2xZhngOLMNcozQrhTTLlGeaYwUJ459czI3+Sqq6uDz+czLgJ9fX1oamo6Ta1663ijD4Xav09+8pP4+c9/jueeew6zZ8+eiDc1NSGdTiMajU4pXwj9CgQCOPvss7F8+XLcddddWLp0Kf75n/+5YPu0detW9Pf344ILLkBJSQlKSkqwfv16fOtb30JJSQkaGxsLsl8nEolEsHDhQrz++usFO08A0NzcjHPPPXdK7Jxzzpn4teVCPy9mKsozMxvlmZnfpzMhzwDFkWuUZ04PxZ5ngMJfO8WWa5RnjjPT+3UyyjNvfb9m5EeuQCCA5cuXY926dROxXC6HdevWYdWqVaexZW8NbW1taGpqmtK/kZERbNy4cUb3z3EcfPKTn8Rjjz2GZ599Fm1tbVN+vnz5cvj9/in96uzsxMGDB2d0vxi5XA6pVKpg+3TFFVfg1VdfxSuvvDLxb8WKFbjxxhsn/nch9utERkdHsXfvXjQ3NxfsPAHA6tWrjW317t27MXfuXACFe17MdJRnZibKM8cphD6dCXkGKI5cozxzeij2PAMU7to5U3KN8kxhoDxzCvr1lkvZv0U8/PDDTjAYdB588EFn586dzs033+xEIhGnt7f3dDctL2KxmPPyyy87L7/8sgPA+cd//Efn5Zdfdg4cOOA4juPcfffdTiQScX76058627Ztc6655hqnra3NGRsbO80td+eWW25xqqqqnOeff945cuTIxL9EIjFR5hOf+IQzZ84c59lnn3W2bNnirFq1ylm1atVpbPWb84UvfMFZv36909XV5Wzbts35whe+4Hg8HudXv/qV4ziF2SfGiW4kjlN4/frsZz/rPP/8805XV5fzu9/9zlm7dq1TV1fn9Pf3O45TeP15g02bNjklJSXO3/7t3zp79uxx/u3f/s0Jh8POv/7rv06UKcTzohBQnpl5KM8UTp8YhZ5nHKc4c43yzOmj0POM4yjXFMpeV54pnH4pz5z6s2LGfuRyHMf59re/7cyZM8cJBALORRdd5Lz44ounu0l589xzzzkAzL+bbrrJcZzjNppf/vKXncbGRicYDDpXXHGF09nZeXob/Saw/gBwHnjggYkyY2Njzl/+5V861dXVTjgcdj7wgQ84R44cOX2NzoOPfexjzty5c51AIODU19c7V1xxxURCcJzC7BPj5KRQaP26/vrrnebmZicQCDizZs1yrr/+euf111+f+Hmh9edEnnjiCWfx4sVOMBh02tvbnfvvv3/KzwvxvCgUlGdmFsozhdMnRqHnGccp3lyjPHP6KOQ84zjKNYWy15VnCqdfyjOn/qzwOI7jvPW/HyaEEEIIIYQQQgghxNvHjNTkEkIIIYQQQgghhBBiOugjlxBCCCGEEEIIIYQoePSRSwghhBBCCCGEEEIUPPrIJYQQQgghhBBCCCEKHn3kEkIIIYQQQgghhBAFjz5yCSGEEEIIIYQQQoiCRx+5hBBCCCGEEEIIIUTBo49cQgghhBBCCCGEEKLg0UcuIYQQQgghhBBCCFHw6COXEEIIIYQQQgghhCh49JFLCCGEEEIIIYQQQhQ8/z9YmVEZ9CKVEAAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 1500x1000 with 3 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "_, ax = plt.subplots(figsize=(15, 10), ncols=3)\n",
-    "inp, tar = train_dset[0]\n",
-    "ax[0].imshow(inp.squeeze())\n",
-    "ax[0].set_title(\"Input\")\n",
-    "ax[1].imshow(tar[0])\n",
-    "ax[1].set_title(\"Target channel 1\")\n",
-    "ax[2].imshow(tar[1])\n",
-    "ax[2].set_title(\"Target channel 2\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.3:** Train the prepared model!\n",
-    "***Note:*** if this takes too long, there were two places above where we gave you options to *(i)* reduce the amount of training data, and *(ii)* chose to train for fewer epochs. Revisit your choices if you want to!\n",
-    "\n",
-    "***Note:*** Depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> above.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using 16bit Automatic Mixed Precision (AMP)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "GPU available: True (cuda), used: True\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "HPU available: False, using: 0 HPUs\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/.venv/lib/python3.10/site-packages/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py:76: Starting from v1.9.0, `tensorboardX` has been removed as a dependency of the `pytorch_lightning` package, due to potential conflicts with other packages in the ML ecosystem. For this reason, `logger=True` will use `CSVLogger` as the default logger, unless the `tensorboard` or `tensorboardX` packages are found. Please `pip install lightning[extra]` or one of them to enable TensorBoard support by default\n",
-      "You are using a CUDA device ('NVIDIA A40-16Q') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/.venv/lib/python3.10/site-packages/pytorch_lightning/callbacks/model_checkpoint.py:654: Checkpoint directory /home/mehdi.seifi/Projects/MicroSplit-reproducibility/examples/2D/HT_H23B/checkpoints exists and is not empty.\n",
-      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/.venv/lib/python3.10/site-packages/torch/optim/lr_scheduler.py:62: UserWarning: The verbose parameter is deprecated. Please use get_last_lr() to access the learning rate.\n",
-      "  warnings.warn(\n",
-      "\n",
-      "  | Name                   | Type                   | Params | Mode \n",
-      "--------------------------------------------------------------------------\n",
-      "0 | model                  | LadderVAE              | 3.0 M  | train\n",
-      "1 | noise_model            | MultiChannelNoiseModel | 144    | train\n",
-      "2 | noise_model_likelihood | NoiseModelLikelihood   | 144    | train\n",
-      "--------------------------------------------------------------------------\n",
-      "3.0 M     Trainable params\n",
-      "144       Non-trainable params\n",
-      "3.0 M     Total params\n",
-      "11.963    Total estimated model params size (MB)\n",
-      "244       Modules in train mode\n",
-      "0         Modules in eval mode\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "00decf5dad694e25b27ac409d2bac1b0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Sanity Checking: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/.venv/lib/python3.10/site-packages/pytorch_lightning/trainer/connectors/data_connector.py:425: The 'val_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=3` in the `DataLoader` to improve performance.\n",
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/.venv/lib/python3.10/site-packages/pytorch_lightning/trainer/connectors/data_connector.py:425: The 'train_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=3` in the `DataLoader` to improve performance.\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d7a05549a3044ed89d018b6b4faf67ac",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Training: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0d4a622f9c2445deb3b1ecb9904fb02a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/mehdi.seifi/Projects/MicroSplit-reproducibility/.venv/lib/python3.10/site-packages/numpy/core/_methods.py:49: RuntimeWarning: overflow encountered in reduce\n",
-      "  return umr_sum(a, axis, dtype, out, keepdims, initial, where)\n",
-      "Metric val_loss improved. New best score: 2.885\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "52209ab9b0534d65bad82eb296f13abb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Metric val_loss improved by 0.033 >= min_delta = 1e-06. New best score: 2.852\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b684c0a9272c4d5486b5412a4c9dcf51",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Metric val_loss improved by 0.003 >= min_delta = 1e-06. New best score: 2.849\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "268efc33289f4c0cae54cc5477cd935e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Metric val_loss improved by 0.004 >= min_delta = 1e-06. New best score: 2.845\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5e0d247d0c3845bebb85819149d15f62",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Metric val_loss improved by 0.001 >= min_delta = 1e-06. New best score: 2.844\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "beaba0a36cb8485995ae2d5bc179ecfa",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Metric val_loss improved by 0.008 >= min_delta = 1e-06. New best score: 2.836\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bce07452b9094c369aadc291a5b57f7b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Metric val_loss improved by 0.014 >= min_delta = 1e-06. New best score: 2.822\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b959ff1a2908471381731f6969ae04d6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Metric val_loss improved by 0.004 >= min_delta = 1e-06. New best score: 2.819\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f166894c0ac548d7a91e26cb0c4014b2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "32aedf24a69347a0822b21e589e35d5e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "`Trainer.fit` stopped: `max_epochs=10` reached.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# create a CAREamics 'Trainer'\n",
-    "trainer = Trainer(\n",
-    "    max_epochs=training_config.num_epochs,\n",
-    "    # NOTE: if you are on a mac swap the accelerator to \"mps\"\n",
-    "    # accelerator=“mps”,\n",
-    "    accelerator=\"gpu\",\n",
-    "    enable_progress_bar=True,\n",
-    "    callbacks=get_callbacks(f\"./checkpoints/\"),\n",
-    "    precision=training_config.precision,\n",
-    "    gradient_clip_val=training_config.gradient_clip_val,\n",
-    "    gradient_clip_algorithm=training_config.gradient_clip_algorithm,\n",
-    ")\n",
-    "# start the training - yay!\n",
-    "trainer.fit(\n",
-    "    model=model,\n",
-    "    train_dataloaders=train_dloader,\n",
-    "    val_dataloaders=val_dloader,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Show training loss curves...\n",
-    "Below, we plot for each epoch of your training run the *(i)* training reconstruction loss, *(ii)* training KL divergence loss, *(iii)* validation reconstruction loss, and *(iv)* validation PSNR. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAE1CAYAAAA241OvAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAy5dJREFUeJzs3Xl4k2XW+PFvkm5JV7pTuoAsZV9kqRREBGRTBLdRUBYXkLFFgRneAQRRGajMOAyOIogvoL7aAeUnOjoKIk7LKHsRWWRfWrbutKVNm7ZJfn+URkK3tE2apD2f6+qlTe88OSlP7j45Ofe5FUaj0YgQQgghhBBCCCGEEE1Iae8AhBBCCCGEEEIIIUTLI0kpIYQQQgghhBBCCNHkJCklhBBCCCGEEEIIIZqcJKWEEEIIIYQQQgghRJOTpJQQQgghhBBCCCGEaHKSlBJCCCGEEEIIIYQQTU6SUkIIIYQQQgghhBCiybnYOwBrMBgMXL16FW9vbxQKhb3DEULUwGg0cuPGDcLCwlAqW15OXOYqIRyfzFMyTwnhDGSukrlKCEdn6TzVLJJSV69eJSIiwt5hCCEsdOnSJcLDw+0dRpOTuUoI5yHzlBDCGchcJYRwdHXNU80iKeXt7Q3A999/j6enZ61jDQYDqampREVFOd2nCs4cOzh3/BK7dRQVFTFixAjTa7alkbnK8Tlz7ODc8TtK7DJPyTzlDJw5fondOmSusmyucqR/s4Zw5vgldvtxlPgtnaeaRVKqsmTT09MTLy+vWscaDAY0Gg1eXl5Od4I5c+zg3PFL7NbVUsusZa5yfM4cOzh3/I4Wu8xTMk85MmeOX2K3Lpmrap+rHPHfrD6cOX6J3X4cLf665in7RyiEEEIIIYQQQgghWhxJSgkhhBBCCCGEEEKIJidJKSGEEEIIIYQQQgjR5JpFTynheIxGI0ajscptLi4uGI1GDAaDnSJrGIndMgqFosX2NhD2Ud1c09jjOetrHZw7/qaKXeYpIaqy9lxa12PJPFU3mausw5nPN3Du+C2JXc5zAfWslEpISKB///54e3sTHBzMhAkTOHXqVJ33W7VqFdHR0ajVaiIiIpgzZw4lJSXVjn3jjTdQKBTMnj27PqFZRG8wcjSjhJRsBUczStAbmuaPb0tiNBopLy9Hr9ebLnBuvdAJDQ01jXOmL4ndsi+9Xk95eXmTXdg2VzJX1a22ucZZXi/O/np31thlnrIOmaeaB6PRNnOpI7zWnT12masap/LcNhqNTnu+tYTXiyOe5/L3renVq1IqOTmZuLg4+vfvT3l5OQsXLmTkyJH8+uuvNW7FmZiYyPz589mwYQOxsbGcPn2aadOmoVAoWLlypdnYAwcO8N5779GzZ8+GP6Ma7E7Tsu5gLtlaPaCCM1kEalTM6OdPbKTG6o/XUun1epRKJUFBQXh4eJhlvo1GI2VlZbi6ujpdRlxit+xxSkpKyMrKQq/X4+IihZgNIXOVZWqbaxrDmV/r4NzxN0XsMk9Zh8xTzYet5tLayDxl2ePIXNU4led2YGAgKpUKNzc3pzvfoHm/XhzxPJe/b/ZRr3/5bdu2mX3/wQcfEBwcTEpKCkOGDKn2Prt372bQoEFMmjQJgLZt2zJx4kT27dtnNq6wsJAnn3yS999/nz//+c/1CatOu9O0LN+VVeX2bK2e5buyWDgkSE4yK6jMcAcFBeHn51ftzxUKhVP+UZDYLePh4QFARkaG6XFtZfXq1fz1r38lPT2dXr168fbbbzNgwIAax3/22WcsXryYixcv0rFjR1asWMHYsWNNP582bRoffvih2X1GjRplNu/l5uYya9YsvvrqK5RKJY888ghvvfVWndumW0rmKsvUNdc09tjO+loH546/qWJvynmqOZJ5qvmw5Vxa1+PKPFU3masa7tZz29fXl9LSUqc836D5v14c6Txvqr9veoOR45k6rhfraaVW0S3YHZXSuf5tra1Rjc7z8/MB8Pf3r3FMbGwsKSkp7N+/H4Dz58/zzTffmL0ZBIiLi+P+++9nxIgRdT6uTqejoKDA7AvAYDBU+Sor1/Pewdxaj7fuYC5l5fpq7+9oXzU9T0f5UigUuLu711jCWcne5aQNKT+V2C37cnd3R6FQ1HoON9bmzZuZO3cuS5Ys4dChQ/Tq1YtRo0aRmZlZ7fjdu3czceJEnn32WX7++WcmTJjAhAkTOHbsmNm40aNHc+3aNdPXP//5T7OfP/nkkxw/fpwdO3bw9ddfs2vXLmbMmGGV56Q3GFlnwVwlJcS/XeRUXsgIUV+VFSG3z5GidjJPNS8ylzo+masaRs5t5+II57klf9/WHsiltLxx72V2p2l59osrLPw+g7/+lM3C7zN49osr7E7TNuq4t3LG5YcNrpEzGAzMnj2bQYMG0b179xrHTZo0iezsbAYPHozRWLG2d+bMmSxcuNA0ZtOmTRw6dIgDBw5Y9NgJCQm89tprVW5PTU1FozHPXp7JV5CjVdV6vGytnp1HUuno6/j/YFDxPB2Ri4sLoaGhlJeXU1paWuO42n7m6CT2upWXl1NeXk56ejrl5eVmP9NqrTPhrly5kunTp/P0008DsHbtWv7973+zYcMG5s+fX2X8W2+9xejRo5k3bx4AS5cuZceOHbzzzjusXbvWNM7d3d209v12J06cYNu2bRw4cIB+/foB8PbbbzN27FjefPNNwsLCGvWcjmfqbpYK1yxbq+d4po6eoXKRBTjdJ4bCcci50zAyTzVP8npwXPJv0zjy+3MOjvDvZMnft9xiPQ9vuoSPu/Lmlwofj5v/dVfie8v3vu5K0/+rXSqauTdFJZazLj9scFIqLi6OY8eO8eOPP9Y6LikpieXLl/Puu+8SExPD2bNneemll1i6dCmLFy/m0qVLvPTSS+zYscPibPaCBQuYO3eu6fuCggIiIiKIioqqsowm7WIRUHvWE8DdL4h2bavvi+UoDAYDqampREVFoVQ2qsjNJiqz266urri5uVU7prJ81hlJ7JYxGit22ggPD6/yR6awsLDRxy8tLSUlJYUFCxaYblMqlYwYMYI9e/ZUe589e/aYzRlQsTTviy++MLstKSmJ4OBgWrVqxbBhw/jzn/9MQECA6Rh+fn6mhBTAiBEjUCqV7Nu3j4ceeqjK4+p0OnQ6nen726s6b5WjLbPg2VeMMxgc+zy8tarTFirnmuqqAW3xOM7KmeO3dey3nkO3n6fOtrtRU7peXPsFe33HCSGEEI6gPn+3CnQGCnQGoLzOsQCuSvB2V5JfUvv1xep9OYR6qfB2V+HlpsTDpX47Ezrz8voGJaXi4+NNS1fCw8NrHbt48WImT57Mc889B0CPHj0oKipixowZvPzyy6SkpJCZmcmdd95puo9er2fXrl2888476HQ6VCrzSid3d3fc3d2rPJZSqaySrAnQuFr0nAI0rg6Z6KlOdc/TERgMBlO5bE3N7Co5Qka8PiR2y1U+hkKhqHKeWuO8zc7ORq/XExISYnZ7SEgIJ0+erPY+6enp1Y5PT083fT969Ggefvhh2rVrx7lz51i4cCFjxoxhz549qFQq0tPTCQ4ONjuGi4sL/v7+Zse5VX2qOnX5CqD2qk4AXV4WFy5Uv0zR0diqqrOyKrOsrMxm57QzV0WCc8ffFLGXlZXZvKKzOWqlrnuOqs84IYQQwhFY+ndr4ZBA2vi43kxM6ckvqfhvgc5AfonelLAqKNGTrzNQqjdSZoDc4ro/8MrXGXjxm9/eU6gU4OmmxNNNidctX7d+7+mqxMtdicZVwep9ObUef93BXGLC1Q7Zv6peSSmj0cisWbPYunUrSUlJtGvXrs77aLXaKm9EK5NMRqOR4cOHc/ToUbOfP/3003Tu3Jk//elPVRJS9dUt2J1AjarWcrxATUWDMeE49AYjKWl5ZN3QEeTtTt9IP4d8ATmqUaNG0bNnT/7617/aOxSn8cQTT5j+v0ePHvTs2ZP27duTlJTE8OHDG3TM+lR1RhqM/PPiNXLqmKuG9wx3+NeCras6LanKtJRpriksJcjLjb6RfujLy2xWWTh69Gh69OhR7WtzxowZ5Ofns3nz5kYdp6VVddbn91bJ1hWdzZVcU4maONt1W+fOnYmPjyc+Pr7OsRqNhk2bNvHggw82QWTCkTjbeQ31O7fFbyz9+xYTrqnXOVBSbqCgxMB/LhTyf7/k1zle7aKgVG9EbwS98daqrMZz5OX19UpKxcXFkZiYyJdffom3t7epOsDX1xe1Wg3AlClTaNOmDQkJCQCMGzeOlStX0qdPH9PyvcWLFzNu3DhUKhXe3t5VelJ5enoSEBBQa68qS6mUCmb086+2lK3SjH7+Dj/BtCTfncgkYdsZ0gt+W/YU6uPOgtEdGdkluJZ7ipagcmvfjIwMs9szMjJq7AcVGhpar/EAd9xxB4GBgZw9e5bhw4cTGhpapZF6eXk5ubm5NR6nPlWdSiU8b8Fc5eriPBUItqrqrKsq01LVzTUhPu78z/B2jOnR2mZVWDXFfWuVYUOP0xKrOuv7e7v9Prao6Gyu5JpKVEeu20RzJOd1y6JSKniwszcbDuXVOKYhf988XJR4eCnpEuQB1J2UWjw0mB4h7uj0Rgp1BgrLDBSWGigqrfjvrf9/63/TC8vr7IkFjru8vl5XXmvWrCE/P5+hQ4fSunVr09etn06mpaVx7do10/eLFi3iD3/4A4sWLaJr1648++yzjBo1ivfee896z6IOsZEaFg4JIlBj/mZOAfzP4ECHXVvZEn13IpPZnx4z+wMAkFGgY/anx/juRNMsW3LmpS/NnZubG3379mXnzp2m2wwGAzt37mTgwIHV3mfgwIFm4wF27NhR43iAy5cvk5OTQ+vWrU3HyMvLIyUlxTTmhx9+wGAwEBMT05inZFI5VwXcNlcFalQOvQ7cGdU012QW6Pjj1pPsOFHzm24hWrKarqn81TJPtUSOct0mhDXJeW0blZueOSKD0chPN3fAc1OZJ56scR1eWYlVm8pKY4VCgYeLkkBPF9r6udE92IOYcA3D7/BifGcfJvX0Y0Y/f+bEBrJ4aDBvjAxlbmygRXF4NLijuG3VKylV0xbw06ZNM41JSkrigw8+MH3v4uLCkiVLOHv2LMXFxaSlpbF69Wr8/PxqfJykpCRWrVpVz6dSu9hIDesntGHZ8CCe6qDH01WBEfBwkU/zbMloNKIt1Zu+im/5/9u/bpSUs+zb01TX3tZ482v5t2e4UVJe4zEqv+rbJHfUqFHMmTOHefPmERERwYMPPsjx48cZP348QUFBtG3blueff57s7GzTfQwGAytXrqR79+74+fnRqVMnVqxYYfr5sWPHGDNmDP7+/oSHhxMXF2e2LGTGjBn87ne/Y9WqVbRr147w8HBmz55NWdlvDa/fe+89evToQatWrWjbti2TJk2q1/OqlJeXx3PPPUdYWBgBAQGMHz+es2fPmn6elpbGI488QlhYGIGBgfTt25dt27YBcP36dZ5++mkiIyPx9/enR48efPTRRw2Kw1rmzp3L+++/z4cffsiJEyf4/e9/T1FRkWk3vilTppg1Qn/ppZfYtm0bf/vb3zh58iSvvvoqBw8eNJU2FxYWMm/ePPbu3cvFixfZuXMn48ePp0OHDowaNQqALl26MHr0aKZPn87+/fv56aefiI+P54knnmj0znu3io3UsGFCG/w8Kqbn5/v6sX5CG3mjV4fb55raviyaa7ZZNtc0ZL651bfffktoaCibNm1q8DGg4nX63HPP0aZNG8LCwpgwYUKTvMYvX77MU089RevWrWnTpg2PPfaYWS+xynlu2bJlREZGEhISwqxZs8wS/zqdjj/84Q9ERUURGhrKiBEjOHjwoNnj/Prrrzz88MOEhIQQHBzMiBEjOH/+vNmY2uZSYV23XlP5uFac/3Exjr2zj7CM1efSGq7bqrsetHQuXb9+PXfccUeVTQkee+wxnn/+ec6fP89jjz1G27ZtCQoKYvDgwfzwww+N/t1UOn78eK3Xd7t27eLuu+8mMDCQ1q1bM2zYMNLS0gA4cuQIo0ePJjg4mJCQEGJjY80+7BK20VTndWOvEWo6tydNmsTMmTOtfm5rNBrWrVvH+PHj8ff3p2vXrmzdutX089LSUubMmUO7du1o1aoV0dHRZm0DNBoNGzdu5PHHHycgIIAePXrw9ddfm36+a9cuWrVqxfbt24mNjcXPz4/du3c3OF5b+v5cEaeyS1G7KFj7YGuWDQ9iSkc9y4YHWeU6vLLSuDaNqTS2JOkF8LfdOWw5no+u3LE2dXHQXJltqJQKeoR44KU1kq/y5KtThSRfLGJAuFxE2UpxmYG+CclWO17GDR0DVuyqc1zKgnvQuNVvmdMnn3zC9OnT2blzJ3l5eYwdO5apU6fyl7/8Ba1Wy6JFi5g8ebLpjdwrr7zCxo0bWbFiBbGxsaSnp3Pq1CkAioqKePDBB4mJieG///0vWVlZvPDCC8ydO5d169aZHnPXrl2Ehoaybds2zp07x5QpU+jZsyfPPPMMKSkp/PGPf2T9+vXcdddd5ObmNngif+GFF7hw4QKfffYZ3t7eLFq0iIceeohDhw7h6upqegP33Xff4enpyYkTJ0w9j15//XVOnDjB1q1bCQwM5Ny5cxQXFzcoDmt5/PHHycrK4pVXXiE9PZ3evXuzbds2UzPztLQ0syU4sbGxJCYmsmjRIhYuXEjHjh354osvTEuEVSoVR44c4cMPPyQvL4+wsDBGjhzJ0qVLzZbfffLJJ8THxzN8+HCUSiWPPPII//jHP6z+/FRKBaFeLuSVlOKnVslSGAvYa66Bhs03AJs3b+bFF19k48aNjB07tlEXljNmzODcuXN8+umneHh48Prrr9v8NV5WVsaDDz7IgAED2LFjBy4uLqxYsYLx48ezf/9+U2+opKQkPDw82LZtG6mpqcycORN/f3/TJgAvv/wyX3zxBevWraN169a88847jB8/nqNHj+Lv78+VK1cYOXIkd999N9988w0+Pj7s2bPH7NPW2uZSYRuV11TRfkYOZCk4m1NKjFxPOT1nmEsffvhh/vCHP5CcnMy9994LQG5uLjt27GDr1q0UFhYyatQoXn31Vdzd3fnkk0949NFH+eWXX4iIiGjU8ykqKuLRRx+t8fquvLycxx9/nKeffpoPP/yQ0tJSDh48aFoy/Mwzz9CrVy/eeust07WHq6tlmzKJhispMzBwpWXnoSVsdY1Q07m9c+dOPv/8c5uc20uXLuX111/nzTffJDExkSlTpnDgwAE6d+7Mu+++y7///W8+/vhjIiIiuHz5MpcvXza7//Lly1m2bBnLly9nzZo1PPPMM5w8eRJ//98SMK+88goJCQm0a9eu1sIUe7mh0/PBz9cBmNTTj2BPVwLVKry0RtqFeKC00nV4ZaXxuoO5ZkvtAjUqZvRr3Ac7liyvD9KoyNLq+eDnPL4+dYMne/kxrJ2nQ7zPaFFJqVsNbavhq1OF7L1UTHGZAbWr9JBo6dq3b8+yZcsAeOONN+jVqxevv/46UPEJy9tvv0337t05c+YMoaGhrF69mpUrV/LUU08BFT2IYmNjgYo3mzqdjv/93//F09MTgJUrV/Loo4+ydOlSU/LEz8+Pv//976hUKqKjoxk9ejRJSUk888wzXLp0CU9PT8aMGYO3tzeRkZH07t273s/r7NmzfPvtt2bL2zZu3EinTp346quvePjhh7l8+TLjx483JWlu3cTg0qVL9OrVi759+wIQFRVV7xhsobYmjklJSVVue+yxx3jssceqHa9Wq9m+fXudj+nv709iYmK94myoyiV8tTU+F85r7dq1vPbaa2zZsoW77767Ucc6e/Ys//73v/nhhx+IiYmhtLSUDRs2EB0dbdPX+JYtWzAYDKxZs8b0huu9996jdevW7Nq1ixEjRgAVS27Xrl2LRqOha9euLFq0iJdffpklS5ZQXFzM+++/z7p16xg1ahSlpaWsXr2aLl268OGHHzJnzhzee+89fHx8+Oijj0xv3jp27GgWS21zqbCtKC8jB7LgdI6u7sFCWEGrVq0YOXIkmzdvNr1x37p1KwEBAdxzzz0olUp69uxpGr9kyRK++uorvv76a37/+9836rE//fRTSkpKeP/9902J/Vuv71xdXcnPz2fMmDHccccdQEXj6UqXLl1i9uzZREdHA9ChQ4dGxSOal+rO7S+++MJ0bqtUKquf2w899JBppcGSJUv44YcfWLNmDW+99RaXLl2iQ4cOxMbGolAoiIyMrHL/p556it/97ncAvPbaa7z77rscPHiQkSNHmsYsXry4wZsGNYUPD+dRoDMQ5efKuM7eNn2s2EgNMeFqjmfquF6sp5W6YsmeNRJDdSW9YsLVJF0s4uNf8sgq0vPWnhy2/lrA1D5+DGijtmsv0hablOrg70Zrbxeu3Shn7yUt997hVfedRL2pXZWkLLgHqEjslJWW4urmVu1JfzA1j+cTf6nzmO9N6kW/KL86H7e++vTpY/r/o0ePkpycTFBQUJVx58+fJy8vD51OZ/qDcbtTp07Ro0cPU0IKKnoSGQwGzpw5Y0pKdenSxWyHydDQUI4fPw7A8OHDiYyMpFu3btx3333cd999PPjgg2g09cuinzp1ChcXF/r372+6LSAggI4dO3Ly5EkAfv/73/PSSy+xc+dO7r33XiZMmECPHj0AmD59OpMmTeLw4cOMGDGCcePGcdddd9UrBlF/ATe3ps1x0IaEjubWuaYu1pxrKh+7PrZu3UpWVhY7d+6kX79+9bpvdU6ePGmX1/jRo0c5d+4cwcHmDV9LSkrMltb16NHDbN6KiYmhsLCQy5cvk5+fT1lZmVl/N1dXV/r162eK/ciRIwwaNKjWaoLa5lJhW5FeFUtTzuSUmjYgEM6rKebSmq4H6zOXPvHEE8TFxfHWW2/h7u7O5s2beeyxx1AqlRQWFrJs2TK2bdtGeno65eXlFBcXV6nwaIiTJ0/SvXv3Gq/vBg8ezFNPPcWDDz7IsGHDGDZsGA8//LCpP+WsWbN44YUX+Oc//8m9997Lww8/bEpeCdvxcFVycP4Qi+Yne18jVHduP/zwwzY7t2/vixoTE8ORI0eAioTTuHHj6NWrF/fddx9jxowxfeBUqfJaAio2K/Px8SEry7xa584772xwfLZ2OlvH9jMVy29/398flyaoGlIpFTbbAa8y6XUso5hTaelER4bSPURtSnoNv8OLu6M8+frUDT49lk9afhlLk7LoFuzOtD6t6BJkn91zW2x5kEKhYGjbij8oSReL7BxN86VQKNC4qUxf6lv+//avQe39CfVxp6apQEHFrheD2vvXeIzKr4ZcFN96gVFYWMjYsWPZu3cve/fuZc+ePezatYsjR44wePBg026TjXX7myyFQmFaR+7t7c3u3bv54IMPCA0NZenSpcTExJCXl2eVx77V008/za+//srEiRM5fvw4gwcPZs2aNUBFv62TJ08ya9Ysrl27xtixY836NQnbqKyUypVKKYvcPtfU9mXNuaYh802vXr0IDAzko48+alQ/qvqwxWu8sLCQPn36mObJyq8jR47w+OOPWy12S+bb2uZSYVttNOCirNi2OqPQMRvYCss11Vxa3fVgfebSsWPHYjQa+fbbb7l8+TI//fSTad5ZsGAB//rXv3j11VfZsWMHe/fupVu3bk22ic26dev4z3/+w1133cWWLVvo1asX+/fvByo2gEpJSWH06NEkJydz55138uWXXzZJXC2ZM10jVHduV1b6N/W53adPH3799VdeeeUViouLmTx5cpX+ti4u5jUu1f39re8H6k1FbzDy7v5cjMC97TzpHmKbRFFTq1xe3zfQSI8QjypVWG4qBQ939eF/J7Th0W4+uKkUHM/UMW97OsuTs7ic3/Q9OVtsUgpgaLuKJMTP10rIK5E3fvamUipYMLpiScbt03fl9wtGd2ySda+9e/fmxIkTREVF0b59e9q3b88dd9xB+/bt8fT0pEOHDqjVav7zn/9Ue//o6GiOHj1KUdFvCc89e/agVCqrLDupjYuLC8OGDWPZsmXs37+f1NTUapem1SY6Opry8nIOHDhgui0nJ4czZ87QpUsX023h4eFMnz6dTZs28dJLL7Fx40bTz4KCgnjqqafYsGEDf/nLX9iwYUO9YhD15y+VUjZj0VwzynZzzR133MG2bdv4+uuvmTt3bqOP17lzZ7u8xnv37s25c+cICgoyzZOVX76+vqZxR48eNetRtX//fry8vAgPD+eOO+7Azc2NPXv2mH5eVlZGSkqKKfbu3bvz008/SeNyB+WihDtaVfQPO5UjO9e2JPa8bvPw8ODBBx9k8+bNfPrpp3Tq1MlU8b53716eeuop05LlkJAQU6PxxurcuTPHjh2r8/qud+/ezJs3j//85z907drVbKfyjh07MmvWLL766ivGjx/P//3f/1klNmEd9n4/Ut253atXL8A253ZlwvTW7yuXlwL4+Pjw6KOP8u677/LRRx/xxRdfkJub26jHdBTbzxZyNrcUT1cFz9zZyt7hNDkvNyXT+rRi3YNhjGzvhVIBuy9peeHrq7yzN4ccbdN90NSik1JtfFzp6O+GwQg/pmrtHY4ARnYJZtXvuhPiY146GOLjzqrfdWdkl+Aa7mldzz//PNevX2fq1KkcPHiQ8+fPs3PnTp5//nn0ej0eHh7MnTuXRYsW8cknn3D+/Hn2799v2nnyiSeewN3dnenTp3P8+HGSk5P5wx/+wKRJk0xL9+ryzTff8O677/LLL7+QlpbGJ598gsFgoFOnTvV6Lh06dGDs2LHEx8eze/dujhw5wjPPPENYWBgPPPAAAPPmzWPHjh1cvHiRn3/+meTkZNMfpNdff52vvvqKc+fO8euvv/Ltt9+a/bEStiE9pWyrtrnmzYc6c1+Xqkt3raljx45s27aNL774gnnz5jXqWB06dOCBBx4gLi6O3bt3c/ToUZ599lmbv8afeOIJAgIC+N3vfsdPP/3ExYsX2bVrF3/4wx/MlhKUlpby+9//nhMnTrBt2zb+/Oc/M3PmTJRKJZ6enkyfPp2FCxfy3XffcfLkSeLi4iguLmbq1KkAzJw5kxs3bjBlyhRSUlI4e/YsiYmJnD59ulG/N2E9HQMqklKns6WvVEtjz+u2J554gm3btvHRRx+ZVWe2b9+eL7/8kl9++YUjR44wbdo0q1VOPv7443h4eDBjxoxqr+8uXrzIK6+8wr59+0hLS+P777/n3LlzREdHU1xczJw5c9i1axdpaWns2bOHlJQUs55TwjHY+/1IU57bW7du5cMPP+TMmTMsXbqUgwcPMnPmTAD+8Y9/8Omnn3Lq1CnOnDnD559/TkhIiEM2K6+v/BI9Hx3OA+Cp3n60Utd/w5rmItDThRcHBvD2/a2JCVdjMMK2s4XM+PIq/3f4OkWlv51jeoORI+klJF8o4kh6CXqDdSr+W2xPqUr3tPPkTG4pSReKeCDato3NhGVGdglmeHQQKWl5ZN3QEeTtTt9IvybdGSAsLIydO3eyaNEiHnzwQXQ6HREREdx3332mXd0WLFiAi4sLS5cu5dq1a4SGhvLcc88BFWWq//rXv5g3bx533303Go2G8ePHs2LFCotj8PPz48svv2TZsmWUlJTQoUMHPvzwQ7p27Vrv57N69WoWLlzII488QmlpKYMGDWLr1q2mJS96vZ45c+Zw5coVfHx8uO+++0yxurm5sWTJElJTU1Gr1cTGxlq8XbxouAB1xfScU6yXPi02Ut1cc2eEL/rypqnI6dSpE99++y2jR48264fUEO+99x7z5s3j0UcfbbLXuEaj4bvvvmPx4sVMnDiRGzduEBYWxtChQ/Hx8TGNGzp0KO3bt2fkyJHodDoee+wxXn75ZdPPly5disFgYPr06dy4ccO0nKVVq4pPLQMCAvjmm294+eWXGTVqlKnR6619qIR9dQpw499U9JUSLY+9rtuGDh1Kq1atOH36tNkb9xUrVjBz5kyGDRtGQEAAc+fO5caNG1Z5TI1Gw5YtW1i4cGG113dqtZpTp07x8ccfk5ubS2hoKDNmzOC5556jvLyc3NxcnnvuOTIzMwkICGD8+PEsWrTIKrEJ67Ln+5Fbz+3KJuJgm3P75ZdfZsuWLcyePZvQ0FA+/PBDU6Wyl5cXK1eu5Ny5c6hUKvr27cvWrVvNdrh2Vht/vk5hqYH2rdwY21FyAABRfm4sHhrM8cwSPvg5jxNZOjYfK+DbM4U83t2XVmoVGw5dt/rOgQAKY1M1tLChgoICfH192bNnj2knjJoYDAYuXLhAu3btUCqV5GrLmfr5FYzA/44PI9TbcbdlvT12R2MwGDAajURFReHuXrVJmtFopLS0FLcaGp07MondcjqdjtTUVBQKRZXztLCwkIEDB5Kfn2/2prWlqM9cVVxazmOfXgFg02PheLk7zyc4tp6r6pprGsOZX+vgePHPmDGDvLw8Pv300zrHNmXsjjBPJSQk8Pnnn3Py5ElTMnDFihV1VqmtWrWKNWvWkJaWRmBgII8++igJCQl4eFT0wtDr9bz66qt8/PHHpKenExYWxrRp01i0aJFFv9eGXFO5BoTzwtfpuKsUbH48okkaxTaWo19T1cUa8dtyLq2No81T9dHcrqnWrFnDmjVruHjxIgDdunXjlVdeYcyYMVy8eNFsp9ZbffrppzXuaGw0GlmyZAnvv/8+eXl5DBo0iDVr1pgtb8zNzTUtYVQqlTzyyCO89dZbdc45t6ptrrr13HZzc3Pa8w1se85pNBo2bdrEgw8+aNXjVrI09trOc1v4NbOE//kuA4C/jgqttrl3S/8bYTQa2Xu5mA9/vs7lgrqX8S0cElRtYsrSecr5fsNW5q9xMXW/T74oS/iEEI7B3UWJxqXiM4Ns6SslRLOTnJxMXFwce/fuZceOHZSVlTFy5EizXjW3S0xMZP78+SxZsoQTJ06wfv16Nm/ezMKFC01jVqxYwZo1a3jnnXc4ceIEK1as4C9/+Qtvv/22zZ5LmLcLnq4KdHojaXnS+0sIZxEeHs4bb7xBSkoKBw8eZNiwYYwfP57jx48TERHBtWvXzL5ee+01vLy8GDNmTI3H/Mtf/sI//vEP1q5dy759+/D09GTUqFGUlJSYxjz55JMcP36cHTt28PXXX7Nr1y5mzJjRFE9ZtHCVzc0BRrb3sttuc45OoVAwMELD6gfCeGFAqxob/1dadzC3UUv5WvzyPahoeP5LeglJF4v4XXcfp8yii5bj0qVLtW6teujQISIiIpowImErvm6gLa/oK9XWz97RiKbiKK/xv/zlL/z1r3+t9mexsbGyY1Qjbdu2zez7Dz74gODgYFJSUhgyZEi199m9ezeDBg0y7X7Utm1bJk6cyL59+8zGjB8/nvvvv9805p///GeVZrbWpFQo6BjgzuH0Ek7n6LjD381mjyWENW3atIlZs2ZV+7PIyEhSUlKaOKKmNW7cOLPvly1bxpo1a0y7uoWGhpr9fOvWrfzud7+rsaLJaDSyatUqFi1axPjx4wH46KOPCAkJ4YsvvuCJJ54w9Rc8cOAA/fr1A+Dtt99m7NixvPnmm4SFhdngmbY8Lf3crsm/T9/gYl4Z3m5Kpvbxs3c4Dk+lVBDu40Zd6aZsrZ7jmTpTsU99SVIKiI3Q8O6+HC7ll3HheplcTAmH1rp1a/bu3Vvrz0Xz4Odm5JpWIc3OWxhHeY0/99xzPPLII9X+rHKpWF3WrVtnzZCatfz8fAD8/f1rHBMbG8vHH3/M/v37GTBgAOfPn+ebb75h8uTJZmPWrVvH6dOn6dSpE7/88gs//vgjK1eurPaYOp0One63BuUFBQVARel/XQ10K39uMBjoGODK4fQSTmXrGNne07InbUe3xu6MrBF/ZQcPo9GIvbp52LuLyNixY02Jkdu5urrWGl9TxH7rv9Ht/9bWPnf1ej2fffYZRUVF1fbsS0lJ4fDhw6xevbrGY1y4cIH09HRGjBhhus3X15eYmBj27NnDE088wZ49e/Dz8zP7vY8YMQKlUsm+fft46KGHqj12feaqW39v1d3urOoTvyXndmVlblOey7X9rLrz3Jpyi/V8/EseAJN7++Ltpqjx8eRvxG9ytJZVQOdoyzAYzPMolj6+JKUATzcl/cM17E7TknSxSJJSwqG5uLjQvn17e4chmoDvzamoKbdkFfbnKK9xf3//WhMkwnoMBgOzZ89m0KBBdO/evcZxkyZNIjs7m8GDB2M0GikvL2fmzJlmy/fmz59PQUEBnTt3RqVSodfrWbZsGU8++WS1x0xISOC1116rcntqaioajWWNS1NTU/EpVwAqjl0r5MKFfIvu5whSU1PtHUKjNCZ+FxcXQkNDKSsrs8sqgdJS+zfGd3d3r7XytKYYmyr2srIyysvLSU9Pp7zc/FpAq7VO25GjR48ycOBASkpK8PLyYuvWrdVuqrN+/Xq6dOlCbGxsjcdKT08HqLLTdEhIiOln6enpBAeb717n4uKCv7+/aUx16jNXVXduO8L51hj1jb+h57Yt1PVYtZ3n1vTRGSXaMiVRXkY6KrO4cCGrzvu05L8RlXT5FX/f6xyXl8WFC5lmt1k6T0lS6qahbT3ZnaZl18UipvXxQylL+BrM2T+FEI0j//7WY0pKSU+pasm5JhrK0c6duLg4jh07xo8//ljruKSkJJYvX867775LTEwMZ8+e5aWXXmLp0qUsXrwYqGhA/Mknn5CYmEi3bt04fPgws2fPJiwsjKlTp1Y55oIFC5g7d67p+4KCAiIiIoiKirKo0XlqaipRUVH4hBhZf+oqGcUKQsOjULs6dtvSW2N31ia2jY2/8nXg4uKCm1vTfiBb2fzYGTVl7AaDARcXF8LDw6skDgsLC63yGNHR0Rw+fJj8/Hy2bNnC1KlTSU5ONktMFRcXk5iYaJpn7KE+c9Xt57Yzn2/Q/F8vtZ3n1nI0o4SU7CwUwIuDQmkfUHdMLf1vRKVIg5F/XrxW68qNQI2K4T3Dq+xOaek8JUmpm/q1UePpqiBbq+dYRsPXQ7ZkCkVFCWRJSYnFSztE81NSUoLRaHTKCdzR+LlVXFTJ8j1zMteIxnKkeSo+Pt7U6Dc8PLzWsYsXL2by5Mk899xzAPTo0YOioiJmzJjByy+/jFKpZN68ecyfP58nnnjCNCY1NZWEhIRqk1Lu7u7V7rymVCot/v0olUqCvJQEaFTkaPVcyCune4hzvDbr8zwdUWPiNxqN6PV6dDodarXaypHV/riVnK2Pa1PHrtPpMBqNqFSqKo9nrfPWzc2NDh06ANC3b18OHDjAW2+9xXvvvWcas2XLFrRaLVOmTKn1WJU9qDIyMsyWmmdkZNC7d2/TmMxM82qK8vJycnNzq/SwulV95qpbz+1brxOc7XyDlvF6qe08t4Zyg5H3DuYBMKaTF9FBlv99asl/I347Bjzfz5/lu2quLJvRzx9Xl6rVVJY+tiSlbnJTKRgU6cl35wpJvlgkSakGqJxEsrIqTlgPDw+zicVoNFJWVobRaHTKSVVir/txSkpKTP/+zvZ7ckSVlVK5kpQyU9dc0xjO/FoH546/KWJ3pHnKaDQya9Ystm7dSlJSUo1br99Kq9VWucBTqVSm49U2pin6YnQKcGOPtpjTOaVOk5RqyWw5l9ZG5inLHsdec5XBYDDr3QQVS/cefPBBgoKCar1vu3btCA0NZefOnaYkVEFBAfv27eP3v/89AAMHDiQvL4+UlBT69u0LwA8//IDBYCAmJsYqz+HWc7sy2eGM5xs079dLU53n/zpZQFp+Gb7uSqb08rPJYzR3sZEaFg4JYt3BXLJveV8SqFExo58/sZGWLfeviSSlbnFPOw3fnSvkxzQtM/v746pyrhe+I6jsX5GRkVHtxFJeXo6Li3OedhJ73SrfFFW+SRKNY6qUKpaeUrera65pDGd+rYNzx98UsTvKPBUXF0diYiJffvkl3t7epl4qvr6+pqqVKVOm0KZNGxISEoCKnbJWrlxJnz59TMv3Fi9ezLhx40zPZ9y4cSxbtozIyEi6devGzz//zMqVK3nmmWds/pw6Bbiz51IxZ3J0dQ8WDsGWc2ltZJ6qW1PMVQsWLGDMmDFERkZy48YNEhMTSUpKYvv27aYxZ8+eZdeuXXzzzTfVHqNz584kJCTw0EMPoVAomD17Nn/+85/p2LEj7dq1Y/HixYSFhTFhwgQAunTpwujRo5k+fTpr166lrKyM+Ph4nnjiCavuvFd5bmdmZqLX6532fIPm/Xqx9XmeXVRO4pGKPodP39kKL3d5j9JQsZEaYsLVHM/Ucb1YTyu1im7B7lWW7DWEc57dNtI92AN/tYrcYj0pV4u5K6JxGb+WSKFQ4OLiUu1OLkajkfT0dJuuF7YVid0ySqXS6X4/jqyyUiqvxECZ3iiJ8lvUNtc0hjO/1sG542+q2B1lnlqzZg0AQ4cONbt948aNTJs2DYC0tDSzqqdFixahUChYtGgRV65cISgoyJSEqvT222+zePFiXnjhBTIzMwkLC+P555/nlVdesflz6hRYMWmdzpaklLOw1VxaG5mnLNMUc1VmZiZTpkzh2rVr+Pr60rNnT7Zv3859991nGrNhwwbCw8MZOXJktcc4deqUafdQgP/5n/8xLSvOy8tj8ODBbNu2zWwZ3SeffEJ8fDzDhw9HqVTyyCOP8I9//MOqz63y3Nbr9U57vkHzf73Y+jz/35TrlJQb6RLkzrA7HH9nWEenUipssqJMklK3UCkVDGmr4YsTN0i6UCRJqUZQKBRVJhiDwUB5eTkKhcLp1uZK7MIePF3AVQllhoptbEO8ZMq+XXVzTWM4++vFmeN35tgbwpIEQFJSktn3Li4uLFmyhCVLltR4H29vb1atWsWqVasaGWH9dfB3RwFkFOnJK9Hj5yGfSDsLa8+ltXHm17ozx16d9evX1zlm+fLlLF++vMaf3z6XKRQKXn/9dV5//fUa7+Pv709iYqLlgTaCQqFw6n8zZz7n7B37oavF/JimRamA3w/wl43MHJhzndlNYGjbigzq/ivFaEtt339BCCFqolCAv7riTV2OVpbwCSEcm6ebknBfVwDOSLWUEEIIOynTG1l7IBeAB6K9uaOVc+5e2FJIUuo27f3dCPdxoVRvZM8lrb3DEUK0cAGam0mpYml2LoRwfJ1ubrN9OqfUzpEIIYRoqbaeKODqjXJaeah4sqefvcMRdZCk1G0UCgX33KyWSrpYZOdohBAtXYCpUkqSUkIIx9cpoGLL9tPS7FwIIYQdZBSWs/loRZ+zZ/u2wtNNUh6OTv6FqjG0XUVS6pf0Eq5LdYIQwo78NZKUEkI4j9+anZc2WeNsIYQQotL7B3PR6Y30CHHnnrbSI9oZSFKqGq29XYkOdMNghF2pUi0lhLCfAHVFc3PpKSWEcAZt/dxwUcKNUgPphTJvCSGEaDoHLmvZe7kYlQJ+39/f6XYsbKkkKVWDyobnyRckKSWEsB/pKSWEcCauKgXt/X+rlhJCCCGagq7cwNqD1wEY38WHSD9pbu4sJClVg8FRnigVFY06rxSU2TscIUQLJT2lhBDORvpKCSGEaGpbjheQUVhOoEbFxB6+9g5H1IMkpWrQSq2id6gHALuk4bkQwk5+6ylVLv1ZhBBOQXbgE0II0ZSu3Shjy/GK5ubP9W2F2lXSHM5E/rVqcc/NhudJF4rkzaAQwi4qK6XKDBU9WoQQwtF1CqyolDqXW0q5Qa6fhBBC2I7RaGTtgVzKDNCntQeDIqW5ubORpFQtBkZocFMpuHKjnHO58mmfEKLpuaoU+LhXTNWyhE8I4Qxae7vg6aakVG8kNU9aIAghhLCdPZeKSblagosSZkpzc6ckSalaaFyVxISrAfiPNDwXQtiJqdm5JKWEEE5AqVD8toQvW/pKCSGEsC69wciR9BK+P3eD1ftyAHikqw9tfFztHJloCElK1aFyF77/pmrRSwm6EMIOAtQuQEVfKSGEcAa/9ZWSpJQQQgjr2Z2m5dkvrrDw+wxW7cklX2dAqYAIX0lIOStJStXhzjA1Xm5Kcov1HM0osXc4QogWyFQpVSyVUkII5/DbDnzS/kAIIYR17E7TsnxXFtm3rR4wGOHNn3LYnaa1U2SiMSQpVQdXlYLBN5ulJcsufEIIO5Dle0IIZ9PxZqVUWl4Z2jLZpEEIIUTj6A1G1h3MrXXMuoO5srrJCUlSygJDb+7C91OallK9nORCiKZVuQOfJKWEEM7CX+NCkEaFEWSzGCGEEI3287XiKhVSt8vW6jmeKcvGnY2LvQNwBl2D3QnSqMjS6jlwRcugSE97hySEaEECPW/2lCqWnlJCCOfRMcCdLK2W09k6eoR42DscIYQQTia/RM+BK8XsuaTl4JVii+5zXdpdOB1JSllAqVAwpK0n/+/XApIvSFJKCNG0pFJKCOGMOgW6sfuSljPSV0oIIYSFMgvL2XNZy95LWo5n6qjvarxWN6+bhfOQpJSF7mlXkZTaf0VLYakBLzdZ+SiEaBqVPaUKdAZK9UbcVAo7RySEEHX7rdm5LKUQQoiWRG8wciyjhFPZCgo1JXQPUaNSVn/9ajQaSc0vY0+alr2Xi6ss+b6jlSsDIzQMCFfzelJWrR/SBmpUdAt2t+pzEbYnSSkLtfNzJdLXlbT8MnanaRnZwcveIQkhWggvNyVuKgWleiO52nJCvWXLWyGE4+vg74YCyCzSc71YL59eCyGEg9AbjBzP1Jnm5m7B7jUmjeprd5qWdQdzb/Z/UsGZLAI1Kmb08yf25gZiBqORk1k69l6qWJp3rfC3FhVKBXQNcmdghIaYCDWhXr9d9z7fz5/lu7JqfOwZ/fyt9jxE05GklIUUCgVD23ny0eE8ki4WSVJKCNFkFAoFAWoV1wrLyS7WS1JKCOEUNG5KIm5+oHcmR8eAcI29QxJCiBbPPGlU4fakUWOOXV3SKFurZ/muLH7X3Yf8EgP7LmvJK/ltZ1ZXJfRpreauCA0x4Wp8Par/ECM2UsPCIUE2i1/YhySl6uGethVJqaPpJeRoywnQyK9PCNE0AjQVSSnpKyWEcCadAtxIyy/jdE6pJKWEEMLO6koaLRwS1ODEjt5gZN3B3FrHfHqswPT/nq4K+rfRcFeEmr5hatSulrXHiY2sSFzZqtJLNL16NUZKSEigf//+eHt7ExwczIQJEzh16lSd91u1ahXR0dGo1WoiIiKYM2cOJSUljT5uUwvxcqFrkDtGYNdFrb3DEUK0IJV9pSQpJYRwJp0Cb/aVypa+UkI4mjVr1tCzZ098fHzw8fFh4MCBfPvtt2Zj9uzZw7Bhw/D09MTHx4chQ4ZQXFzzLmht27ZFoVBU+YqLizONGTp0aJWfz5w502bPU1SwJGm07mAueoMRg9GItsxAjracKwVlnM3RcSyjhANXivlvahHfnb3BlycL2Hw0nw9+vs7aA7m89p9Ms+qlmsSEe7B0eDAfPxrBHwcHMjjK0+KEVCWVUkHPUA/uaedJz1APSUg5uXqV+iQnJxMXF0f//v0pLy9n4cKFjBw5kl9//RVPz+p3pEtMTGT+/Pls2LCB2NhYTp8+zbRp01AoFKxcubLBx7WXe9p68muWjuSLRTzU1cfe4QghWogAdcV0naMtr2OkEEI4jk4BbgCczinFaDSiUMgbByEcRXh4OG+88QYdO3bEaDTy4YcfMn78eH7++We6devGnj17GD16NAsWLODtt9/GxcWFX375BaWy5gTCgQMH0Ot/S0wcO3aM++67j8cee8xs3PTp03n99ddN32s0Uklpa8czdXUmjbK1eh7dlEaZodZhjTIkyos+rdW2ewDhdOqVlNq2bZvZ9x988AHBwcGkpKQwZMiQau+ze/duBg0axKRJk4CK7PnEiRPZt29fo45rL4OjNKw7mMvZ3FIu55cR7iu9XYQQtldZKZVbLJVSQjQHCQkJfP7555w8eRK1Wk1sbCwrVqwgOjq61vutWrWKNWvWkJaWRmBgII8++igJCQl4eHgAFddZqampVe73wgsvsHr1aps8l9pE+bnhqoTCUgPXCssJk554QjiMcePGmX2/bNky1qxZw969e+nWrRtz5szhxRdfZP78+aYxdc1RQUFBZt+/8cYbtG/fnnvuucfsdo1GQ2hoaCOfgaiP6xZeQ96akFIqwMNFgdpVidpFgYeL0vz7W27PKyln+9miOo8vm16I2zWqKVJ+fj4A/v7+NY6JjY3l448/Zv/+/QwYMIDz58/zzTffMHny5AYfV6fTodP9VgZeUFCxNtVgMGAw1J7Wrfx5XeNq4u2moE9rDw5eLSHpQiGTevo26DgN0djY7c2Z45fYrcMRYnBWsnxPiObFVtXnllYpNBVXlYI7/N04lV3K6exSSUoJ4aD0ej2fffYZRUVFDBw4kMzMTPbt28eTTz5JbGws586do3PnzixbtozBgwdbdMzS0lI+/vhj5s6dW6VK8pNPPuHjjz8mNDSUcePGsXjx4lqrpRr6/s+RroMbwprx+3lYVqn6h1h/eod64OGiwE2lsLjCVW8wcvBqSa3XqoEaFV0CXR3+30POG+vGUZcGJ6UMBgOzZ89m0KBBdO/evcZxkyZNIjs7m8GDB2M0GikvL2fmzJksXLiwwcdNSEjgtddeq3J7amqqxaWf1X2KaKkuGgUHUfH9mXzu8sqlqSvRGxO7I3Dm+CX2xtFqpRdbQ/2WlJLle0I0B7aqPre0SqEpdQpwr0hK5egY2s6x2jII0dIdPXqUgQMHUlJSgpeXF1u3bqVr167s3bsXgFdffZU333yT3r1789FHHzF8+HCOHTtGx44d6zz2F198QV5eHtOmTTO7fdKkSURFRREWFsaRI0f405/+xKlTp/j8889rPFZj3/85wnVwY1gj/kItKFFhoKY3r0b83CDckEnutYY9xvhwBRtOVy7vvPVxjAA8GF5KWurFhh3cDuS8aRxL3/s1OCkVFxfHsWPH+PHHH2sdl5SUxPLly3n33XeJiYnh7NmzvPTSSyxdupTFixc36LgLFixg7ty5pu8LCgqIiIggKioKLy+vWuMxGAykpqYSFRVV63ro2oSGG/j0wlWydVDmE0b0zSaetmaN2O3JmeOX2K2jsLDQro/vzEw9pYr10pdFiGbIFtXntVUpVGqK6vOO/hXVUaezdXb/1LaSo3yK3FDOHL/Ebh3WiiE6OprDhw+Tn5/Pli1bmDp1KsnJyabjP//88zz99NMA9OnTh507d7JhwwYSEhLqPPb69esZM2YMYWFhZrfPmDHD9P89evSgdevWDB8+nHPnztG+fftqj9XQ93+OdB3cENaK/8CVYv5xMAfDzeRQ9RTMjAmgfUTD+3u1awfBIVreT8kzq5gK1LjwXF8/Yhtx7KYk5411WPrer0FJqfj4eL7++mt27dpFeHh4rWMXL17M5MmTee6554CKiaeoqIgZM2bw8ssvm/2SLD2uu7s77u5VE0FKpdLiX3p9xt7O013JXRFqki9q2ZVaTJfgpm3U1pjYHYEzxy+xNz4G0TCV6+/LDVCgM+DrIevxhWgubFV9XlOVwq2aovpcXQzgwtkcHWfPXUDlQH8K7P0pcmM5c/wSe+NYq/rczc2NDh06ANC3b18OHDjAW2+9Zeoj1bVrV7PxXbp0IS0trc7jpqam8v3339da/VQpJiYGgLNnz9aYlGrs+z9HuA5ujIbGbzAa2Xw0n8Qj+RiBrkHujGjvReKRPLOm54EaFTP6+RMb2fik0eAoLwZGeHIso5hTaelER4bSPUTtlDvktdTzxpqPb4l6JaWMRiOzZs1i69atJCUl0a5duzrvo9VqqwSjUqlMx2voce1taFtPki9q+W9qEc/1beWULzIhhPNwVSnw81CSV2IgR6uXpJQQzYitqs9rqlK4VVNUn7c1GvE8foWiMlC0akM7f7daj9sUHOVT5IZy5vglduuwVfW5wWBAp9PRtm1bwsLCOHXqlNnPT58+zZgxY+o8zsaNGwkODub++++vc+zhw4cBaN26dYNiFtXTlhlYuTubvZeKARjbyYvpff1xVSkYfocnxzN1XC/W00qtoluwu1Xfz6qUCnqEeOClNdIuxAOlvFcWtahXUiouLo7ExES+/PJLvL29SU9PB8DX1xe1uqJaaMqUKbRp08ZU0jlu3DhWrlxJnz59TBdQixcvZty4cabklCXHdTR9wtT4uFe8QfwlvYQ7wxwzTiFE8xGgdiGvpJQcbTl3OMCbOiFE49mq+tzSKoWmqj7vFOjOz9dKOJNbRsdAD4uO2xTs/SlyYzlz/BJ742NorAULFjBmzBgiIyO5ceMGiYmJJCUlsX37dhQKBfPmzWPJkiX06tWL3r178+GHH3Ly5Em2bNliOsbw4cN56KGHiI+PN91mMBjYuHEjU6dOxcXF/O3muXPnSExMZOzYsQQEBHDkyBHmzJnDkCFD6NmzZ6Ofk6hwOb+MZbuyuJRfhosSXhjgz8gO3qafq5QKeoY6zlwsWrZ6JaXWrFkDwNChQ81u37hxo6k0PC0tzWySXLRoEQqFgkWLFnHlyhWCgoIYN24cy5Ytq9dxHY2LUsHgKA3fnC4k6WKRJKWEEDbnr1Fx7npFXykhhHOzVfV5pfpUKTSFTgEVSanTOTrG4l33HYQQNpeZmcmUKVO4du0avr6+9OzZk+3bt3PfffcBMHv2bEpKSpgzZw65ubn06tWLHTt2mC2xO3fuHNnZ2WbH/f7770lLS+OZZ56p8phubm58//33rFq1iqKiIiIiInjkkUdYtGiRbZ9sC7L/spY3f8pGW2YkQKNi4ZCgJuuBLERD1Hv5Xl2SkpLMH8DFhSVLlrBkyZJGHdcRDW3ryTenC9mTpkU3wIC7i3N+2iOEM1q9ejV//etfSU9Pp1evXrz99tsMGDCgxvGfffYZixcv5uLFi3Ts2JEVK1YwduzYasfOnDmT9957j7///e/Mnj3bdHvbtm2r9JFISEgw9V2wtd924JOklBDOzlbV51B7lYK9dAqsqO48nV1q50iEEJXWr19f55j58+fXep1z8eLFKreNHDmyxvd3ERERJCcnWxyjsFxl/6hPjlRsnNE1yJ0FQ4JMfUmFcFSOcaXipLoEuRPiqSKjSM/+K8XcHSXbHAvRFDZv3szcuXNZu3YtMTExrFq1ilGjRnHq1CmCg4OrjN+9ezcTJ04kISGBBx54gMTERCZMmMChQ4eqNBXeunUre/furbEHy+uvv8706dNN33t7N90n/gFqSUoJ0VzYqvocaq9SsJdOARWf0l/KL0NbZkDjKh/kCSGEtWhLb/aPulzRP+r+Tt4817cVrirp5SQcnySlGkGhUDCkrSefHS8g+UKRJKWEaCIrV65k+vTppi2K165dy7///W82bNhQ7ad5b731FqNHj2bevHkALF26lB07dvDOO++wdu1a07grV64wa9Ystm/fXuOSF29vb0JDQ23wrOoWoKmYsnOKy+3y+EII67FV9TnUXqVgL63UKoI8VWQV6TmbUyq9TIQQwkou55fx5+RMLheU46KEuJgA7mtf+0YVQjgSSUo10tB2FUmpg1eLuaHT4+0u5ZFC2FJpaSkpKSksWLDAdJtSqWTEiBHs2bOn2vvs2bPHbHcpgFGjRvHFF1+YvjcYDEyePJl58+bRrVu3Gh//jTfeYOnSpURGRjJp0iTmzJlT4/IYnU6HTqczfV9QUGB6LIPBUOvzrPz5reMC1BWVBdlafZ33t6fqYncWzhw7OHf8jhK7vR+/OesU4E5WkZbTOTpJSgkhhBXsu6zlb9I/Sjg5SUo1UpSfG239XLmYV8ZPaVpGd5TmnULYUnZ2Nnq9npCQELPbQ0JCOHnyZLX3SU9Pr3Z8ZQ8XgBUrVuDi4sKLL75Y42O/+OKL3Hnnnfj7+7N7924WLFjAtWvXWLlyZbXjExISeO2116rcnpqaikajqfFxbh9bqVgL4EJWYSkXLlyw6P72dHv/LWfizLGDc8dv79i1Wq1dH7856xTgxk9pWk7nSF8pIYRoDIPRyKaj+STe7B/VLdid+XdL/yjhnCQpZQVD23nywc95JF0okqSUEE4oJSWFt956i0OHDqFQ1Lz2/tZqq549e+Lm5sbzzz9PQkJCtVuqL1iwwOw+BQUFREREEBUVhZdX7WXVBoOB1NRUoqKiTD1lgkoN8MsVtOUKwiKiHHZzhepidxbOHDs4d/yOEnthYaHdHru563Tz0/sz2bo6RgohhKiJttTA33Zns+9m/6gHoiv6R7kopX+UcE6SlLKCIW0rklLHMnVkFZUT5Cm/ViFsJTAwEJVKRUZGhtntGRkZNfZ6Cg0NrXX8f//7XzIzM4mMjDT9XK/X84c//IFVq1ZVu7MMQExMDOXl5Vy8eJHo6OgqP3d3d682WaVUKi1+033rWG93Be4qBTq9kes6I2Fujp10qM/zdDTOHDs4d/z2jt1Zf2/OoL2/GwogS6vnerFePtEXQoha6A1GjmWUcCpbQaGmhO4haq7eKGfZzf5Rrjf7R42Q/lHCyUn2xAqCPV3oHuzOsUwdm4/m0SNETSu1im7B7qgkYy2EVbm5udG3b1927tzJhAkTgIoKi507dxIfH1/tfQYOHMjOnTuZPXu26bYdO3YwcOBAACZPnsyIESPM7jNq1CgmT55saqZencOHD6NUKqvd8c8WFAoFARoVV2+Uk6PVE+bt2iSPK4QQ1qBxVRLh60pafhmnc3TEhFu2jFkIIVqa3Wla1h3MJVurB1RwJgtvNyU6vYFSPQTe7B/VSfpHiWZAklJWEu7jyrFMHdvOFrHtbBFQMVnM6OdPbKRcdAlhTXPnzmXq1Kn069ePAQMGsGrVKoqKikwJpClTptCmTRsSEhIAeOmll7jnnnv429/+xv3338+mTZs4ePAg69atAyAgIICAgACzx3B1dSU0NNRUAbVnzx727dvHvffei7e3N3v27GHOnDk89dRTtGrVqsme+61JKSGEcDadAt0qklLZpZKUEkKIauxO07J8V1aV22+UVmzEEeHjwvL7QqXaVDQbkpSygt1pWradrdqDIlurZ/muLBYOCZLElBBW9Pjjj5OVlcUrr7xCeno6vXv3Ztu2baZm5mlpaWZLcGJjY0lMTGTRokUsXLiQjh078sUXX9C9e3eLH9Pd3Z1Nmzbx6quvotPpaNeuHXPmzKmyq5+tBahdAB052vImfVwhhLCGTgHufH+uiNM50ldKCCFupzcYWXcwt9YxxeVGfNxlqbloPiQp1UiWTBzrDuYSE66WpXxCWFF8fHyNy/WSkpKq3PbYY4/x2GOPWXz82/tI3Xnnnezdu7c+IdpEgKbiU7GcYqmUEkI4n04BbgCczinFaDTWurmEEEK0NMczdTeX7NUsW6vneKaOnqEeTRSVELYlKdZGqs/EIYQQjWVKSsnyPSGEE2rbyg1XJRSVGrh6Qyo+hRDiVtct/NDR0nFCOANJSjWSTBxCiKYkSSkhhDNzUSpo71/RmFeW8AkhhLl8nWXXd9JPSjQnkpRqJEsnBJk4hBDWUNFTCnKKpcJACOGcOgXeXMKXXWrnSIQQwjEUlxl470Au6w5er3NsoKZil3chmgtJSjVSt2B3AjW1J5xk4hBCWEtlpVSuVo/BaLRzNEIIUX+dAqRSSgghKh2+Vkz811f56tQNAHqF1N4rakY/f+lVLJoVaXTeSCqlghn9/KvdtrOSTBxCCGtppVahAPRGyC8xSBWmEMLpVFZKnc8tpUxvxFUl10hCiJanqNTAhkPX2X5zF/cgTxWzYgK4M0zN7jQt6w7mmvUuDtSomNHPX3Z1F82OJKWsIDZSw8IhQVUmDh93JfExATJxCCGsxkWpwM9DxfUSPTnacklKCSGcTmsvF7zclBSWGkjNK6VDgFSTCyFalgOXtbyzP9fUI/T+Tt5M7eOHxrViIVNspIaYcDXHMoo5lZZOdGQo3UNkN3fRPElSykoqJ47jmTr+eSSPo5k67mmrkYSUEMLqAjQ3k1LFejrYOxghhKgnhUJBpwA3Dl0r4XSOJKWEEC3HDZ2edQev858LRQC09nbhpbsC6F7Nkj2VUkGPEA+8tEbahXiglISUaKakp5QVqZQKeoZ68EBnbwAOXS2xc0RCiOZIduATQji7ToE3+0plS18pIUTL8FNaEb//6ir/uVCEUgEPdfHh7ftbV5uQEqIlkUopG+gdqkalgCs3ykm/UUaot6u9QxJCNCOSlBJCOLtOATd34MuRHfiEEM3b9WI9aw/k8lOaFoAIX1deuiuAzkFSJSoESFLKJjzdlHQJcudYpo6DV0t4IFqSUkII6wlQV0zdOcXldo5ECCEapuPNJXuX8svQlhrQuEnxvhCieTEajSRfrGhYXqAzoFTAY918eaKHr2zwIMQt5ArARvqGqQFIuVps50iEEM2NVEoJIZxdK7WKYE8VRuBsrlRLCSGal2xtOa8nZfHmT9kU6Ay0a+XK38e0ZnJvP0lICXEbqZSykb5t1Hx4OI8j6SWU6o24yeQjhLCSQElKCSGagU4B7mQWaTmdo6NnqPRUEUI4F73ByPFMHdeL9bRSq+gW7I5SATvOFfK/KdfRlhlxUcLEHn480s0HF2lULkS1pFLKRtr5ueKvVqHTGzmeKQ3PhRDWE6C5uXxPK8v3hBDOq1Pgzb5S2VIpJYQ9rFmzhp49e+Lj44OPjw8DBw7k22+/NRuzZ88ehg0bhqenJz4+PgwZMoTi4ppXgrz66qsoFAqzr86dO5uNKSkpIS4ujoCAALy8vHjkkUfIyMiwyXO0ld1pWp794goLv8/grz9ls/D7DKZ9fplZ/77GP/bmoi0z0inAjbfGtubxHr6SkBKiFpKUshGFQkHfsIpP/Q5ekSV8QgjrCVBXVEoVlRkpKTfYORohhGiYTjf7Sp3OkR34hLCH8PBw3njjDVJSUjh48CDDhg1j/PjxHD9+HKhISI0ePZqRI0eyf/9+Dhw4QHx8PEpl7W8hu3XrxrVr10xfP/74o9nP58yZw1dffcVnn31GcnIyV69e5eGHH7bZ87S23Wlalu/KIvu2ivXrJQYu5pXhooRn7mzFX0eFEuXnZqcohXAesnzPhvqGqdlxroiUq8VMt3cwQohmQ+OmRO2ioLjcSI5WTxsf+XxBCOF82vu7oVRAtlZPrrYcf41clgrRlMaNG2f2/bJly1izZg179+6lW7duzJkzhxdffJH58+ebxkRHR9d5XBcXF0JDQ6v9WX5+PuvXrycxMZFhw4YBsHHjRrp06cLevXu56667GvGMbE9vMLLuYG6tY7zdlIzv7I1KqqOEsIi8k7Gh3q3VKBVwuaCcjEJZZiOEsB5pdi6Ec0tISKB///54e3sTHBzMhAkTOHXqVJ33W7VqFdHR0ajVaiIiIpgzZw4lJeZtAq5cucJTTz1FQEAAarWaHj16cPDgQVs9lQZTuyqJ9K3YofhMjizhE8Ke9Ho9mzZtoqioiIEDB5KZmcm+ffsIDg4mNjaWkJAQ7rnnnipVT9U5c+YMYWFh3HHHHTz55JOkpaWZfpaSkkJZWRkjRoww3da5c2ciIyPZs2dPjcfU6XQUFBSYfQEYDIY6vywdZ8nXsYziKhVSt7teUjHOWo9pzfib+ktil/gtIR9J2ZCXm5IuQe4cz9SRcrWYsZ287R2SEKKZ8Ne4cLmgXPpKCeGkkpOTiYuLo3///pSXl7Nw4UJGjhzJr7/+iqenZ7X3SUxMZP78+WzYsIHY2FhOnz7NtGnTUCgUrFy5EoDr168zaNAg7r33Xr799luCgoI4c+YMrVq1asqnZ7FOAe5czCvjdI6OmAiNvcMRosU5evQoAwcOpKSkBC8vL7Zu3UrXrl3Zu3cvUNEj6s0336R379589NFHDB8+nGPHjtGxY8dqjxcTE8MHH3xAdHQ0165d47XXXuPuu+/m2LFjeHt7k56ejpubG35+fmb3CwkJIT09vcY4ExISeO2116rcnpqaikZT99yRmppa5xhLnMpWAKq6x6Wl46U1WuUxwXrx24PEbj/2jl+r1Vo0TpJSNtY3TM3xTB0Hr0hSSghhPZV9pXKKpVJKCGe0bds2s+8/+OADgoODSUlJYciQIdXeZ/fu3QwaNIhJkyYB0LZtWyZOnMi+fftMY1asWEFERAQbN2403dauXTsbPAPr6Bjgxnfn4LRUSglhF9HR0Rw+fJj8/Hy2bNnC1KlTSU5ONlU4PP/88zz99NMA9OnTh507d7JhwwYSEhKqPd6YMWNM/9+zZ09iYmKIiori008/5dlnn21wnAsWLGDu3Lmm7wsKCoiIiCAqKgovL68a72cwGEhNTSUqKqrOXliWKNSUwJmsOsdFR4bSLqTxu4paO/6mJLHbj6PEX1hYaNE4SUrZWL8wNR8dzuNIRglleiOuKllbLIRoPFm+J0Tzkp+fD4C/v3+NY2JjY/n444/Zv38/AwYM4Pz583zzzTdMnjzZNOZf//oXo0aN4rHHHiM5OZk2bdrwwgsvMH169d0tdTodOt1vjcZvXxJTm1uXBzRUB/+K5Xuns3WU6/UoFU1znWSN2O3JmeOX2K3DWjG4ubnRoUMHAPr27cuBAwd46623TH2kunbtaja+S5cuZsvx6uLn50enTp04e/YsAKGhoZSWlpKXl2dWLZWRkVFjHyoAd3d33N3dq9yuVCotetNt6bi6dA9RE6hR1bqEL1CjonuIGqUVe0pZK357kNjtx97xW/rYkpSysXatXGnloeJ6iZ7jmSX0bq22d0hCiGZAklJCNB8Gg4HZs2czaNAgunfvXuO4SZMmkZ2dzeDBgzEajZSXlzNz5kwWLlxoGnP+/HnWrFnD3LlzWbhwIQcOHODFF1/Ezc2NqVOnVjlmY5fEVI5tKKMBXBUqisrgwImLBDfxZZK9lzY0ljPHL7E3jqXLYurLYDCg0+lo27YtYWFhVXrdnT592qwaqi6FhYWcO3fOlDzv27cvrq6u7Ny5k0ceeQSAU6dOkZaWxsCBA633RGxEpVQwo58/y3fVXC01o5+/NDkXoh4kKWVjCoWCvmEefH++iINXiyUpJYSwigB1xfSdUyw9pYRwdnFxcRw7dqzOBsJJSUksX76cd999l5iYGM6ePctLL73E0qVLWbx4MVDxhrJfv34sX74cqFhuc+zYMdauXVttUqqhS2IqH8saywPan8vgZHYpWnUw7dpV30/L2hxlaUNDOXP8Ert1WLospjYLFixgzJgxREZGcuPGDRITE0lKSmL79u0oFArmzZvHkiVL6NWrF7179+bDDz/k5MmTbNmyxXSM4cOH89BDDxEfHw/AH//4R8aNG0dUVBRXr15lyZIlqFQqJk6cCICvry/PPvssc+fOxd/fHx8fH2bNmsXAgQMdfue9SrGRGhYOCeIvP2ZRfkvBWqBGxYx+/sRGSn88IepDklJNoG8bNd+fLyLlagnP9bV3NEKI5kAqpYRoHuLj4/n666/ZtWsX4eHhtY5dvHgxkydP5rnnngOgR48eFBUVMWPGDF5++WWUSiWtW7eudrnN//t//6/aYzZ2SUx9x1YnOtCdk9mlnM0tY3j7pn2jb++lDY3lzPFL7I2PobEyMzOZMmUK165dw9fXl549e7J9+3buu+8+AGbPnk1JSQlz5swhNzeXXr16sWPHDtq3b286xrlz58jOzjZ9f/nyZSZOnEhOTg5BQUEMHjyYvXv3EhQUZBrz97//HaVSySOPPIJOp2PUqFG8++67jX4+TWlghBp3lYJyg5Gpvf2IDnSnW7C7VEgJ0QCSlGoCfUI9UCrgUn4ZmYXlBHvJr10I0TiVSancYj16g1EugoRwMkajkVmzZrF161aSkpIsakau1WqrvBFVqVSm4wEMGjSo2uU2UVFRVorc+joFuAM3OJ2jq3OsEMJ61q9fX+eY+fPnm/pLVefixYtm32/atKnOY3p4eLB69WpWr15d51hHlVdioKjMiFIB47v44CZ9g4VoMOf8eMLJeLmr6BxY8SnkwavFdo5GCNEctPJQoVSAwQj5JVItJYSziYuL4+OPPyYxMdG0TXp6ejrFxb9dJ0yZMoUFCxaYvh83bhxr1qxh06ZNXLhwgR07drB48WLGjRtnSk7NmTOHvXv3snz5cs6ePUtiYiLr1q0jLi6uyZ+jpToFugFwLreUMr31tlAXQghbSc2r2DE01MtFElJCNJKU7DSRvmFqfs3ScehqMWM7eds7HCGEk1MpFfh5qMgt1pNTrMdfI9O5EM5kzZo1AAwdOtTs9o0bNzJt2jQA0tLSzCqjFi1ahEKhYNGiRVy5coWgoCDGjRvHsmXLTGP69+/P1q1bWbBgAa+//jrt2rVj1apVPPnkkzZ/Tg0V6uWCt5uSG6UGLuaV0jGg6nJCIYRwJGn5ZQBE+rraORIhnJ+8i2kifcM8+L9f4Jf0Esr0Rlwloy6EaKQAzc2klFZPxwB7RyOEqI/K5Xa1SUpKMvvexcWFJUuWsGTJklrv98ADD/DAAw80JrwmpVAo6BToRsrVEk5nS1JKCOH4TEkpP0lKCdFYsnyvidzh74afh5LiciO/ZpXYOxwhRDMgzc6FEM1Fp5uJKOkrJYRwBml5lZVSbnaORAjnJ0mpJqJUKOgbpgYg5YokpYQQjRegrih2zSkut3MkQgjROJ0CKt7Ync4ptXMkQghRO6PRKMv3hLCieiWlEhIS6N+/P97e3gQHBzNhwoQqO7xUZ9WqVURHR6NWq4mIiGDOnDmUlJgnZlavXk3btm3x8PAgJiaG/fv31++ZOIHKpJQ0OxdCWINUSgkhmouONzeEuZxfRlGpwc7RCCFEza4X6yksNaBUQLgkpYRotHolpZKTk4mLi2Pv3r3s2LGDsrIyRo4cSVFRUY33SUxMZP78+SxZsoQTJ06wfv16Nm/ezMKFC01jNm/ezNy5c1myZAmHDh2iV69ejBo1iszMzIY/MwfUp7UHSkXFGuSsIqlsEEI0jiSlhBDNhZ+HihBPFUbgbK4s4RNCOK7KKinZeU8I66hXUmrbtm1MmzaNbt260atXLz744APS0tJISUmp8T67d+9m0KBBTJo0ibZt2zJy5EgmTpxoVgm1cuVKpk+fztNPP03Xrl1Zu3YtGo2GDRs2NPyZOSBvdxXRNz8JTJFqKSFEIwVWJqWKJSklhHB+nW5eI53OliV8QgjHJU3OhbCuRu2+l5+fD4C/v3+NY2JjY/n444/Zv38/AwYM4Pz583zzzTdMnjwZgNLSUlJSUliwYIHpPkqlkhEjRrBnz55qj6nT6dDpfvsUraCgAACDwYDBUHvJd+XP6xpnK31C3TmRpePglWJGtves133tHXtjOXP8Ert1OEIMzUllT6lsrVReCiGcX8cAd/6bqpVm50IIh/Zbk3NJSglhDQ1OShkMBmbPns2gQYPo3r17jeMmTZpEdnY2gwcPxmg0Ul5ezsyZM03L97Kzs9Hr9YSEhJjdLyQkhJMnT1Z7zISEBF577bUqt6empqLRaCyKPzU11aJx1tYaABd+vqrlzLkLuDSg1by9YrcWZ45fYm8crVZr7xCalcrle8VlRrRlBjSusneFEMJ5dQqUZudCCMf3W5Nz2XlPCGtocFIqLi6OY8eO8eOPP9Y6LikpieXLl/Puu+8SExPD2bNneemll1i6dCmLFy9u0GMvWLCAuXPnmr4vKCggIiKCqKgovLy8ar2vwWAgNTWVqKgolMqmfwMXZTTyv2eukl9ioNirNT1DPCy+r71jbyxnjl9it47CwkK7Pn5zo3ZVonFVoC0zkqPVo/F1rnNTCCFu1cHfDaWiok9etracQE2jCvqFEMLqzHbek+V7QlhFg/7ax8fH8/XXX7Nr1y7Cw8NrHbt48WImT57Mc889B0CPHj0oKipixowZvPzyywQGBqJSqcjIyDC7X0ZGBqGhodUe093dHXd39yq3K5VKi99012esNSmBO1ur+c+FIg5d09G7tWWVXWbHsFPs1uLM8UvsjY9BWFeAxgVtfhk52nIipIxcCOHEPFyURPq6cjGvjDM5pZKUEkI4HLOd93zkuksIa6jXO0Sj0Uh8fDxbt27lhx9+oF27dnXeR6vVVnkjqlKpTMdzc3Ojb9++7Ny50/Rzg8HAzp07GThwYH3Ccxr9wtSANDsXQjRegFqanQshmo/KZudnpK+UEMIByc57QlhfvT6CiouLIzExkS+//BJvb2/S09MB8PX1Ra2uSLRMmTKFNm3akJCQAMC4ceNYuXIlffr0MS3fW7x4MePGjTMlp+bOncvUqVPp168fAwYMYNWqVRQVFfH0009b87k6jD5hHigVkJpXRlZROUGe8kmgEKJhKvtK5WglKSWEcH6dAtz47qzswCeEcEyydE8I66tXNmTNmjUADB061Oz2jRs3Mm3aNADS0tLMKqMWLVqEQqFg0aJFXLlyhaCgIMaNG8eyZctMYx5//HGysrJ45ZVXSE9Pp3fv3mzbtq1K8/PmwsddRccAN05ll3LoajGjOnrbOyQhhJOSpJQQojm5tVLKYDSiVEglghDCcVTuvBclLROEsJp6JaWMRmOdY5KSkswfwMWFJUuWsGTJklrvFx8fT3x8fH3CcWr9wtScyi4l5WqJJKWEEA0WoK6YxnOKy+0ciRBCNF6UryvuKgVFZUauFpQTLm/8hBAOpLJSKkJ23hPCaqTrsJ30vdlX6nB6MeWGupN9QghRHamUEkI0Jyqlgvb+FW/2TktfKSGEAzEajaTK8j0hrE6SUnbSIcANX3cl2jIjJ7LkoksI0TCSlBJCNDcdAyqTUtJXSgjhOK4X6ymSnfeEsDpJStmJUqHgTtmFTwjRSJW77+WV6NFL1aUQohmo7Ct1+FoxyReKOJJeIvObEMLuKpfutZad94SwKklK2VHlEr6DVyQpJYRoGF8PFUoFGIxwvUSqpYQQzq9QVzGXXS4o568/ZbPw+wye/eIKu9O0do5MCNGSVS7di5Cle0JYlSSl7KhPaw8UwMW8MrK10qRYCFF/KqUCf7Us4RNCNA+707SsOXC9yu3ZWj3Ld2VJYkoIYTeXZOc9IWxCklJ25OuhMvVNOCRL+IQQDSR9pYQQzYHeYGTdwdxax6w7mCtL+YSwkjVr1tCzZ098fHzw8fFh4MCBfPvtt2Zj9uzZw7Bhw/D09MTHx4chQ4ZQXFzz+5aEhAT69++Pt7c3wcHBTJgwgVOnTpmNGTp0KAqFwuxr5syZNnmO1lS5fC9Sdt4TwqokKWVnpiV8V0vsHIkQwlkFqF0AyCmWikshhPM6nqkju47kerZWz/FM2SBGCGsIDw/njTfeICUlhYMHDzJs2DDGjx/P8ePHgYqE1OjRoxk5ciT79+/nwIEDxMfHo1TW/BYyOTmZuLg49u7dy44dOygrK2PkyJEUFRWZjZs+fTrXrl0zff3lL3+x6XNtLNl5TwjbcbF3AC1dvzZq/nk0n8PXiik3GHFRStM8IUT9SKWUEKI5uF5s2Rx2uaCMnqEeNo5GiOZv3LhxZt8vW7aMNWvWsHfvXrp168acOXN48cUXmT9/vmlMdHR0rcfctm2b2fcffPABwcHBpKSkMGTIENPtGo2G0NBQKzyLppF7y857bWTnPSGsSiql7KyDvxs+7kq0ZUZOZsknf0JYavXq1bRt2xYPDw9iYmLYv39/reM/++wzOnfujIeHBz169OCbb76pcezMmTNRKBSsWrXK7Pbc3FyefPJJfHx88PPz49lnn6WwsNAaT6dRJCklhGgOWt3sj1eXNftzWfJDBskXiigpN9g4KiFaBr1ez6ZNmygqKmLgwIFkZmayb98+goODiY2NJSQkhHvuuYcff/yxXsfNz88HwN/f3+z2Tz75hMDAQLp3786CBQvQamvvF6fT6SgoKDD7AjAYDHV+WTqutq/UvFKgYuc9F4Wx0cerz5c14rfXl8Qu8VtCKqXsTKVU0Ke1B8kXtRy8Wkz3EPnkT4i6bN68mblz57J27VpiYmJYtWoVo0aN4tSpUwQHB1cZv3v3biZOnEhCQgIPPPAAiYmJTJgwgUOHDtG9e3ezsVu3bmXv3r2EhYVVOc6TTz7JtWvXTOXoTz/9NDNmzCAxMdFmz9USpqSUhVUGQgj7S0hI4PPPP+fkyZOo1WpiY2NZsWJFnVUIq1atYs2aNaSlpREYGMijjz5KQkICHh4V1w+vvvoqr732mtl9oqOjOXnypM2ei7V0C3YnUKOqdQmfixLKDZBytYSUqyWoXRUMitQwrJ0X3UPcUSqk4lyI+jh69CgDBw6kpKQELy8vtm7dSteuXdm7dy9QMae8+eab9O7dm48++ojhw4dz7NgxOnbsWOexDQYDs2fPZtCgQWbXW5MmTSIqKoqwsDCOHDnCn/70J06dOsXnn39e47ESEhKqzG0AqampaDSaOmNJTU2tc0xtfr6mAFQEuJZy4cKFRh2rIRobvz1J7PZj7/jrSjZXkqSUA+gXpib5opZDV4uZ1qeVvcMRwuGtXLmS6dOn8/TTTwOwdu1a/v3vf7NhwwazEvNKb731FqNHj2bevHkALF26lB07dvDOO++wdu1a07grV64wa9Ystm/fzv333292jBMnTrBt2zYOHDhAv379AHj77bcZO3Ysb775ZrVJrKZi6ilVJD2lhHAWlX1X+vfvT3l5OQsXLmTkyJH8+uuveHp6VnufxMRE5s+fz4YNG4iNjeX06dNMmzYNhULBypUrTeO6devG999/b/rexcU5LvdUSgUz+vmzfFdWjWP+Z3AQkb6u/OdCEUkXCsko0vP9uSK+P1dEkKeKoW09GXaHFxGyO5YQFomOjubw4cPk5+ezZcsWpk6dSnJysqnC4fnnnzddb/Xp04edO3eyYcMGEhIS6jx2XFwcx44dq1JdNWPGDNP/9+jRg9atWzN8+HDOnTtH+/btqz3WggULmDt3run7goICIiIiiIqKwsvLq8YYDAYDqampREVF1doLqy7/zswFiujc2o927XwbfJz6slb89iCx24+jxG/pihLnuEpp5u4MU6MAzl8vI1dbjr9G/lmEqElpaSkpKSksWLDAdJtSqWTEiBHs2bOn2vvs2bPH7EIGYNSoUXzxxRem7w0GA5MnT2bevHl069at2mP4+fmZElIAI0aMQKlUsm/fPh566KEq99HpdOh0vy3Lvb3UvDa3lt3Wxd+jojIgp1iPXq9HYedKgfrE7micOXZw7vgdJfamenxL+67cavfu3QwaNIhJkyYB0LZtWyZOnMi+ffvMxrm4uDhVr5ZbxUZqWDgkiHUHc80qpgI1Kmb08yc2sqIiYnJvP57s5cuvmTp+uFDEj6lFZBXp+ex4AZ8dL6CjvxvD7vBkSFtPfD3MlwXqDUaOZZRwKltBoaaE7iFqVNLTU7RQbm5udOjQAYC+ffty4MAB3nrrLdOHfF27djUb36VLF9LS0uo8bnx8PF9//TW7du0iPDy81rExMTEAnD17tsaklLu7O+7u7lVuVyqVFr3ptnRcTS4VVHzwF+XnZpc3+Y2N354kdvuxd/yWPrZkPxyAr4eKDgFunMkpJeVaCfe1rznbL0RLl52djV6vJyQkxOz2kJCQGpenpKenVzs+PT3d9P2KFStwcXHhxRdfrPEYty8NdHFxwd/f3+w4t2psqXnl2LqU6gFcKCk3cuLsRdQOMrPbu2S4MZw5dnDu+O0du6Wl5tZWU9+VW8XGxvLxxx+zf/9+BgwYwPnz5/nmm2+YPHmy2bgzZ84QFhaGh4cHAwcOJCEhgcjIyGqP2VTJ8/q4K9yD/mGt+TVLR26xHn+1iq5B7qiUiiqP1TXIja5Bbky/05cDV0r4z4UiUq6VcCa3lDO5pfxvynXubO3BvXd4MqCNmoNXi3k/Je9mDz4VnMkiQKNiel8/YiMsm5cdgaMkcRtCYrcOW8VgMBjQ6XS0bduWsLAwTp06Zfbz06dPM2bMmBrvbzQamTVrFlu3biUpKYl27drV+ZiHDx8GoHXr1o2K3VaMRiNpsvOeEDbjIG9dRL8wdUVS6kqxJKWEaGIpKSm89dZbHDp0yKpVRg0tNYf6l916/nyZojIjXsHhRNp52YqjlAw3hDPHDs4dv6PEbo/NC2rqu3K7SZMmkZ2dzeDBgzEajZSXlzNz5kwWLlxoGhMTE8MHH3xAdHQ0165d47XXXuPuu+/m2LFjeHt7VzlmUyXPG8Lr5hdaSLPgIdoAT0XB+DA4lK3gQJaSS0UKDlwt4cDVEtyURkpN7+N/m+tztOW88d9snulkoFeA0erPw5bsncRtDIm9cayRQF+wYAFjxowhMjKSGzdukJiYSFJSEtu3b0ehUDBv3jyWLFlCr1696N27Nx9++CEnT55ky5YtpmMMHz6chx56iPj4eKBiyV5iYiJffvkl3t7epg/ufH19UavVnDt3jsTERMaOHUtAQABHjhxhzpw5DBkyhJ49ezb6OdnCrTvvhcvOe0JYnSSlHETfMDX/PJrPz+kl6A1GKSMXogaBgYGoVCoyMjLMbs/IyKhxuUpoaGit4//73/+SmZlpVkmg1+v5wx/+wKpVq7h48SKhoaFkZmaaHaO8vJzc3NwaH7expeb1GRugcaEov4zrJQbatnKMZIS9S4Ybw5ljB+eO396x2+Oxa+q7crukpCSWL1/Ou+++S0xMDGfPnuWll15i6dKlLF68GMCsgqFnz57ExMQQFRXFp59+yrPPPlvlmE2ZPG9KPTvBNOBSfhn/uVDEfy4UkVNcU2VJxTXXvy67Me7O1k5xDebIv/u6SOzWYY0EemZmJlOmTOHatWv4+vrSs2dPtm/fzn333QfA7NmzKSkpYc6cOeTm5tKrVy927NhhtsTu3LlzZGdnm75fs2YNAEOHDjV7rI0bNzJt2jTc3Nz4/vvvWbVqFUVFRURERPDII4+waNGiRj8fW6mskmrt5YKryvHnByGcjSSlHETHADd83JUU6AyczNbRLVh24ROiOm5ubvTt25edO3cyYcIEoOIicefOnaZP6W43cOBAdu7cyezZs0237dixg4EDBwIwefJkRowYYXafUaNGMXnyZFNzz4EDB5KXl0dKSgp9+/YF4IcffsBgMJh6IdhTgEZFWn7ZzSUpQghnUZ++K4sXL2by5Mk899xzQEWD4KKiImbMmMHLL79c7ZtkPz8/OnXqxNmzZ6s9ZlMmz+0hqpU701q50ydMzcvfZ9Y6Nlur50R2GT1DnecazJF/93WR2BsfQ2OtX7++zjHz58+vdhOZShcvXjT73misvdowIiKC5ORki+JzFLJ0TwjbkqSUg1ApFfRp7UHyRS0pV4slKSVELebOncvUqVPp168fAwYMMH3aVplAmjJlCm3atDHtDPPSSy9xzz338Le//Y3777+fTZs2cfDgQdatWwdAQEAAAQEBZo/h6upKaGioaXv2Ll26MHr0aKZPn87atWspKysjPj6eJ554wq4771UK0FQ08pWklBDOoSF9V7RabZU3oiqVynS86hQWFnLu3Lkqfadamrwaq6TMXS+WOVQIYS4t72ZSytfNzpEI0Tw558cTzdSdYWoAUq6U2DkSIRzb448/zptvvskrr7xC7969OXz4MNu2bTM1M09LS+PatWum8bGxsSQmJrJu3Tp69erFli1b+OKLL2rt3VKdTz75hM6dOzN8+HDGjh3L4MGDTYktewu42d08p7jczpEIISwRFxfHxx9/TGJioqnvSnp6OsXFxaYxU6ZMMdtpdNy4caxZs4ZNmzZx4cIFduzYweLFixk3bpwpOfXHP/6R5ORkLl68yO7du3nooYdQqVRMnDixyZ+jI2mlVtU9CNiVWsgNnSSmhBC/MVVK2blnpxDNlVRKOZA7W1ckpc5dL+V6sd7iCyghWqL4+Pgal+slJSVVue2xxx7jscces/j4t5ejQ8WuWImJiRYfoylJpZQQzqWuvitQkWC/tTJq0aJFKBQKFi1axJUrVwgKCmLcuHEsW7bMNOby5ctMnDiRnJwcgoKCGDx4MHv37iUoKMjmz8mRdQt2J1CjIruOOXLf5RKe/9dVpvT24772Xk7RX0oIYTtGo5G0vFJAlu8JYSuSlHIgrdQqOvi7cTa3lJSrxYyQXfiEEBaSpJQQzqWuvitQNcHu4uLCkiVLWLJkSY332bRpU2NDa5ZUSgUz+vmzfFdWjWMm9fTlx1QtafllvLMvl+1nCpk5wJ/owKo9t4QQLUNusZ6iMqPsvCeEDcnyPQfTt3IJ39XiOkYKIcRvAtSSlBJCiNrERmpYOCSIQI15JXqgRsXCIUFM6unHP+5vzfS+rdC4KjiTW8oftqXzjz055JfI3CpES1S5dC/MW3beE8JWpFLKwfRr48HmY/kculaC3mCUsnEhhEUCNBXTeV6JnnKDEReZO4QQoorYSA0x4WqOZRRzKi2d6MhQuoeoTddbLkoF47v4MKStJx/8fJ2d54v47lwhP13SMrmXH2M6ypI+IVqSyibnEdJPSgibkUopB9MpwB0vNyVFpQZOZevsHY4Qwkn4eihxUYIR2T1KCCFqo1Iq6BHiQd9AIz1CPKpNMrVSq5gTG8hfRoZwRytXikoNrD2Qy5xvr/FrpmxII0RLkZovO+8JYWuSlHIwKqWCPq09AEi5Khc9QgjLKBUK0+YIsoRPCCGso2uwB38f05rf9/fH003J+etl/M93GazcnS0fAAjRAlyqTEpJk3MhbEaSUg6on/SVEkI0QIC6YglfTnG5nSMRQojmQ6VUcH+0N+seDGNkBy8UwA/ni3j+X1f48kQB5Ya6m9YLIZzPrTvvRcnyPSFsRpJSDujOm0mps7ml8imcEMJisgOfEELYjq+HihfvCuDN0aF09HdDW2bk/ZTrvPTNNY6k/1bdrjcYOZJeQvKFIo6kV/QIFUI4n5xbdt5rIzvvCWEz0ujcAbVSq2jv78a53FIOXStm+B1e9g5JCOEEJCklhBC2Fx3ozt/GhPLd2UI+OpxHal4ZC7/PYEiUhp6hHmw6mk/2LfNwoEbFjH7+xEZq7Bi1EKK+LsnOe0I0CamUclD9wm72lboiS/iEEJYJkJ5SQgjRJJQKBaM7evPeg2GM7VSxpG9XqpZ39uWaJaQAsrV6lu/KYnea1iqPrTcYOZpRQkq2gqMZUoklhK1U7rwnTc6FsC2plHJQfcPUbD5WwM/XKi42ZPthIURdAjXSU0oIIZqSt7uKFwYEMOIOT/7nuwzKDTWPXXcwl5hwdaOu6XanaVl3sDLxpYIzWVKJJYSNVO68FyH9pISwKUlKOajoQHc83ZTcKDVwOqeULkHu9g5JCOHgKpfv3f4pvRBCCNsqKafWhBRUzM3P/+sKEb5uBGpUBGpcCNSoCNCoCPJ0IUCjwsOl5kUMu9O0LN+VVe1xl+/KYuGQIElMCWFFpkop2XlPCJuSpJSDUikV9An14Mc0LSlXiyUpJYSoU2VSKlerx2g0olBIhaUQQjQFSzemSS/Uk15Yc2sGLzdllYRVoKcLAWol7+7PqfXY1qjEEkJUMBqNXMqXnfeEaAqSlHJgfduoK5JSV4p5qpefvcMRQjg4/5s9pXR6I0WlBrzcVXaOSAghWoZWasvm26m9/fB2V5Kt1ZOtLSdHq6/4/6JyisuNFJYaKCw1cPFmhUZ9ZGv1HM/U0TPUo973FUKYk533hGg6kpRyYH1bV1xUnMktJa9Ej4+bfPIlhKiZu4sS75vLfrOL9ZKUEkKIJtIt2J1AjarW5dOBGhUPd/WptpLJaDSiLTOSrS03JamytfqbSatyUvPKyLGgGsvSii0hRO0ql+7JzntC2J4kpRyYv8aFO1q5cv56GYeuFjO0rfQJEELULkCj4kapgRytnrZ+9o5GCCFaBpVSwYx+/tX2fKo0o59/jUvrFAoFnm4KPN3ciPKr+vMj6SUs/D6jzjgsrdgSQtQuLV923hOiqdTcTVE4hL5hagBSrtbcf0AIISpV9pXKkWbnQgjRpGIjNSwcEkSgxjwxFKhRNboJeWUlVm0CNSq6BUsPUiGswZSUkibnQticVEo5uL5t1Hx2vIBDV0vQG4z2DkcI4eAC1BXTeo623M6RCCFEyxMbqSEmXM3xTB3Xi/W0UlckihrbfNySSqwne/lJk3MhrMS08540ORfC5qRSysF1CXTH01XBjVIDZ3NL7R2OEMLBmSqlpK+IEELYhUqpoGeoB/e086RnqIfVEkU1VWJVHv7fp25QXGawymMJ0ZIZjUbSbu68J0kpIWxPKqUcnEqpoHdrNT+laUm5WsJAb3tHJIRwZLJ8Twghmq/KSqxjGcWcSksnOjIUf40Lf/oug7O5pSTsyuKVe4NxkYopIRosp1iPVnbeE6LJSKWUE6jsK3XoWomdIxFCOLqAm01ucyUpJYQQzZJKqaBHiAd9A430CPEgwteNJfcG465ScOhaCf/Ym4PRKC0fRN3WrFlDz5498fHxwcfHh4EDB/Ltt9+ajdmzZw/Dhg3D09MTHx8fhgwZQnFx7b1uV69eTdu2bfHw8CAmJob9+/eb/bykpIS4uDgCAgLw8vLikUceISOj7kb+TUV23hOiadUrKZWQkED//v3x9vYmODiYCRMmcOrUqVrvM3ToUBQKRZWv+++/3zSmsLCQ+Ph4wsPDUavVdO3albVr1zbsGTVDfcM8ADiTU0phmZ2DEUI4tADNzZ5SxdJTSgghWoroQHfmDwlCqYAfzhfx4eE8e4cknEB4eDhvvPEGKSkpHDx4kGHDhjF+/HiOHz8OVCSkRo8ezciRI9m/fz8HDhwgPj4epbLmt5CbN29m7ty5LFmyhEOHDtGrVy9GjRpFZmamacycOXP46quv+Oyzz0hOTubq1as8/PDDNn++lpKd94RoWvVKSiUnJxMXF8fevXvZsWMHZWVljBw5kqKiohrv8/nnn3Pt2jXT17Fjx1CpVDz22GOmMXPnzmXbtm18/PHHnDhxgtmzZxMfH8+//vWvhj+zZiRA40JbPxeMwLeXlBzNkKbnQojqVS7fyysxUKaXeUIIIVqK/m3UvHhXAABbjhfw1ckCO0ckHN24ceMYO3YsHTt2pFOnTixbtgwvLy/27t0LVCSPXnzxRebPn0+3bt2Ijo7md7/7He7uNe/yuHLlSqZPn87TTz9tKjTQaDRs2LABgPz8fNavX8/KlSsZNmwYffv2ZePGjezevdv0uPZmanIuO+8J0STq1VNq27ZtZt9/8MEHBAcHk5KSwpAhQ6q9j7+/v9n3mzZtQqPRmCWldu/ezdSpUxk6dCgAM2bM4L333mP//v08+OCD9QmxWdqdpiWjsGIpzo8ZSn7MyCJQo2JGP/9GbS8shGh+fNyVuCih3ADXi/UEe0nrQCGEaClGtPciR6vn/37JY93B67RSqxgc5WnvsIQT0Ov1fPbZZxQVFTFw4EAyMzPZt28fTz75JLGxsZw7d47OnTuzbNkyBg8eXO0xSktLSUlJYcGCBabblEolI0aMYM+ePQCkpKRQVlbGiBEjTGM6d+5MZGQke/bs4a677qr22DqdDp1OZ/q+oKAi6WowGDAYam7wX/mz2sbcrrLJeYSPS73uZwsNid9RSOz24yjxW/r4jXq3kp+fD1RNPNVm/fr1PPHEE3h6/vYHMjY2ln/9618888wzhIWFkZSUxOnTp/n73/9e7TEaOilVjrn1v45u9yUtb/w3p8rt2Vo9y3dlMf/uAGIjnCMx5Wy/+1tJ7NbhCDE0dwqFggC1iowiPTnF5ZKUEkKIFuZ33X3ILS7n36cLefOnbHw9VPQI8bB3WMJBHT16lIEDB1JSUoKXlxdbt26la9eupqqlV199lTfffJPevXvz0UcfMXz4cI4dO0bHjh2rHCs7Oxu9Xk9ISIjZ7SEhIZw8eRKA9PR03Nzc8PPzqzImPT29xjgTEhJ47bXXqtyempqKRlP3e6HU1NQ6xwAYjXDxugpQoCzM4MIFi+5mc5bG74gkdvuxd/xardaicQ1+t2IwGJg9ezaDBg2ie/fuFt1n//79HDt2jPXr15vd/vbbbzNjxgzCw8NxcXFBqVTy/vvv11h91dhJqXKsozMYYe2hym1/q2uyZ2TtvmxCyvQ40yYrzvC7r4nE3jiWTkyicQI0LhVJKWl2LoTDSkhI4PPPP+fkyZOo1WpiY2NZsWIF0dHRtd5v1apVrFmzhrS0NAIDA3n00UdJSEjAw6Nq0uGNN95gwYIFvPTSS6xatcpGz0Q4GoVCwYx+/lwvNrD7kpY/J2WyYmQobVtJfxxRVXR0NIcPHyY/P58tW7YwdepUkpOTTR8kPv/88zz99NMA9OnTh507d7JhwwYSEhKaNM4FCxYwd+5c0/cFBQVEREQQFRWFl5dXjfczGAykpqYSFRVVay+sStnackr011AqYEDntnZvdF7f+B2JxG4/jhJ/YWGhReManJSKi4vj2LFj/PjjjxbfZ/369fTo0YMBAwaY3f7222+zd+9e/vWvfxEVFcWuXbuIi4sjLCzMrLSzUkMnJXCcfyBLHM0oIa80q5YRCvJKQevZ2ik+AXOm3/3tJHbrsHRiEo1T2VdKklJCOK7KPp39+/envLychQsXMnLkSH799VezavJbJSYmMn/+fDZs2EBsbCynT59m2rRpKBQKVq5caTb2wIEDvPfee/Ts2bMpno5wMCqlgj8MCiBvp55fs3S88kMmb44OJdhTqmeFOTc3Nzp06ABA3759OXDgAG+99Rbz588HoGvXrmbju3TpQlpaWrXHCgwMRKVSVdlJLyMjg9DQUABCQ0MpLS0lLy/PrFrq1jHVcXd3r7aXlVKptOj61tJxlwsqrp3CvF1wd1XVMbrpWBq/I5LY7cfe8Vv62A36yxQfH8/XX3/Nrl27CA8Pt+g+RUVFbNq0iddff93s9uLiYhYuXMjWrVtNO/L17NmTw4cP8+abb1ablGrspFTfsfaSV2JZk+KcYoPDP5dbOcPvviYSe+NjELbnr5aklBCOriF9Onfv3s2gQYOYNGkSAG3btmXixIns27fPbFxhYSFPPvkk77//Pn/+859t8wSEw3N3UfLK0CD+57sM0vLLWPJDJn8ZGYK3u+O80RaOx2AwoNPpaNu2LWFhYVV2Wj99+jRjxoyp9r5ubm707duXnTt3MmHCBNPxdu7cSXx8PFCR+HJ1dWXnzp088sgjAJw6dYq0tDQGDhxouydmIdPOe35SWShEU6lXUspoNDJr1iy2bt1KUlIS7dq1s/i+n332GTqdjqeeesrs9rKyMsrKyqq8WVWpVC2+/0wrtWUXDR/8fB03lYJBkRoUCidaxyeEsIkATcXUnlNcbudIhBCWsqRPZ2xsLB9//DH79+9nwIABnD9/nm+++YbJkyebjYuLi+P+++9nxIgRdSalWlKfzls5c+xgefwaVwVLhgbyP99lcim/jNeTMnn93iDcXez3IZEz/+4dKXZrxLBgwQLGjBlDZGQkN27cIDExkaSkJLZv345CoWDevHksWbKEXr160bt3bz788ENOnjzJli1bTMcYPnw4Dz30kCnpNHfuXKZOnUq/fv0YMGAAq1atoqioyLQE0NfXl2effZa5c+fi7++Pj48Ps2bNYuDAgTU2OW9KlTvvRfnKzntCNJV6JaXi4uJITEzkyy+/xNvb29SMztfXF7VaDcCUKVNo06ZNlXXG69evZ8KECQQEBJjd7uPjwz333MO8efNQq9VERUWRnJzMRx99VKUUvaXpFuxOoEZFdi3VDgogt9jAG//NpmOAG0/3aUXPUMdfyieEsJ3Am8v3aps7hBCOw9I+nZMmTSI7O5vBgwdjNBopLy9n5syZLFy40DRm06ZNHDp0iAMHDlj02C2lT2dNnDl2sDz+5zrBP46pOJFVyus7LvFMtMHu/Uid+XfvCLFbo09nZmYmU6ZM4dq1a/j6+tKzZ0+2b9/OfffdB8Ds2bMpKSlhzpw55Obm0qtXL3bs2EH79u1Nxzh37hzZ2dmm7x9//HGysrJ45ZVXSE9Pp3fv3mzbts2s+fnf//53lEoljzzyCDqdjlGjRvHuu+82+vlYQ2rlznuSlBKiydQrKbVmzRoAhg4danb7xo0bmTZtGgBpaWlVqp5OnTrFjz/+yHfffVftcTdt2sSCBQt48sknyc3NJSoqimXLljFz5sz6hNfsqJQVjSqX76q5r9TcQQFcu1HO578WcCanlIXfZ9A3zINpfVrRThpaCtEiSU8pIZyLpX06k5KSWL58Oe+++y4xMTGcPXuWl156iaVLl7J48WIuXbrESy+9xI4dO6ptfF6dltKn83bOHDvUP/52gG9QCUt+yOLodSXbs735ff9Wdqmwd+bfvSPFbo0+nbdvPlWd+fPnm/pLVefixYtVbouPjzdVTlXHw8OD1atXs3r1aovibCpGo5FLpuV7kpQSoqnUe/leXZKSkqrcFh0dXet9Q0ND2bhxY31CaTFiIzUsHBLEuoO5ZlUPgRoVM/r5ExtZ8SnmmI7ebDqaz7YzN0i5WsKhq9cY2s6Tyb38ZEt4IVqY35JS5RiNRlnWK4QDq0+fzsWLFzN58mSee+45AHr06EFRUREzZszg5ZdfJiUlhczMTO68807TffR6Pbt27eKdd95Bp9OhUpm3BmgpfTpr4syxQ/3i7xmq4Y+DA3ljVzbbzhYR6OnCEz38bBtgLZz5d+8Isdv78ZujHK0ebZkRpQLaeEtSSoimItkKJxAbqSEmXM2xjGJOpaUTHRlK9xA1qlvqrlupVfx+gD/ju3jzf4fz+G+qlv9cKOK/qUU8EO3N77r74iONLYVoEQLUFVN7mQFulBrktS+EA2pIn06tVlttD87K4w0fPpyjR4+a/fzpp5+mc+fO/OlPf6qSkBItz6BIT2b01/Peget8/Es+/moXRnaovSJOiJYi9WaVVJi3C64q+UBPiKYiSSknoVIq6BHigZfWSLsQD5Q1NAII83blT3cH8XBXHRt/zuNIeglfnLjBd2cLebSbLw929sbDjs0thRC256pS4OOupEBnIEerl6SUEA6oIX06x40bx8qVK+nTp49p+d7ixYsZN24cKpUKb2/vKj2pPD09CQgIqLVXlWhZxkX7kKvV89nxAt7Zl0MrDyX9wy3rHyZEc1bZ5Fx23hOiaUlSqpnqGODOsuHBHLpWwgc/X+fC9TI+OpzH16du8GRPX0a09zKrtNIbjBzP1HG9WE8rtYpuwe5mPxdCOJcAjcqUlGrXqukeV28wciyjhFPZCgo1JVWqOoUQFRrSp3PRokUoFAoWLVrElStXCAoKYty4cSxbtqypwhbNxJTefuQW69l5vog3/pvN8vtCiA6suoxTiJaksp+U7LwnRNOSpFQzplAo6Bumpk9rD5IvFvHx4TwyivS8vS+XrScKmNqnFXeFq9lzqbjOnlVCCOcSoHbhwvUycrTlTfaYu9O0t8wlKjiTJXOJEDVoSJ9OFxcXlixZwpIlSyx+nOp6fQqhUCiYdVcAeSV6Uq6W8Np/MvnrqFDa+MibcdFyVe68J03OhWhaso6rBVAqFNzbzou1D7Zhet9W+LgruVxQzrLkLGZ+dZXlu7KqbB2frdWzfFcWu9Mav92sEKLpmZqdFzfNDny707QylwghhBNxUSqYf3cQHf3dKNAZeGVnBjnaco6kl5B8oYgj6SXoDXUnT4VoDm7deS9CKqWEaFJSKdWCuKoUjO/iw4j2Xnz+az5bfy3gSkHtVRTrDuYSEy7Lb4RwNr/twGf7pJTeYGTdwdxax8hcIoQQjkftqmTJsGDmbU/n2o1yntl6Bf0teSipdhUtReXOeyrZeU+IJieVUi2Qp5uSyb1bMXdQYJ1js7V6jmfqmiAqIYQ1BaibLil1PFNXpULqdjKXCCGEY/LzUDGhszeAWUIKpNpVtBymnfd8XGXnPSGamCSlWjC9wbJx15to+Y8QwnoCNBWFsDnFtu8pZekc8cXJAvZf1nJDJ3OKEEI4Cr3ByGfHC2ods+5grizlE81a5c57snRPiKYny/dasFZqy7aJ/+b0DTRuSu5s7SFLb4RwEk25fM/SuWT/5WL2Xy4GINLXlS5B7nQNcqdrsDuhXi4oFHXPL7JTqBBCWFd9ql17hno0UVRCNK20m03OZec9IZqeJKVasG7B7gRqVHVeiBzP0nH8P5kEaFSMuMOT+9p7ESprrYVwaJVJqQKdgTK90aal6JbMJV5uSu4K9+BEVilXbpSTll9GWn4Z288WAuDnoaRrkAddg93pEuROe383XG5LNpnv7ldB+p0IIUTjWFrtKpXzojlLu7l8T3beE6LpSVKqBVMpFczo58/yXVk1jnn2Tj+ytHr+c76IHK2ezccK2HysgJ4h7tzXwYvYCA3uLrIKVAhH4+2mxFUJZYaKJXyhXra7yLJkLnnxrgBT4ii/RM+JLB2/Zun4NVPH2VwdeSUGdl/SsvtSRd8Sd5WCjgFudAt2p0uQBwU6PSt351Q5bmW/k4VDgiQxJYQQDWBptaul44RwNrfuvBcplVJCNDlJSrVwsZEaFg4JqrP64Ok+rdh7Wct3Zws5fK2EIxk6jmToWOt2naFtNdzX3osOAe72ehpCiNsoFAoCNC6kF5aTo9XbNCkFEBOuxttNyY1S82Z11VUy+XqouCtCw10RFbeV6o2cyalIUP2apeNklo4bpQaOZeo4lqkDau91ArK7nxBCNJQl1a6Bmorl0kI0R9m37LwXJqtBhGhykpQSxEZqiAlX19qnxVWl4O4oT+6O8iSzsJzvzxfy/blCMov0/Pt0If8+XcgdrVy5r4MX97b1xMvd/NM0vcHIsYwSTmUrKNSU0D1E3jwKYWsBGpUpKWVrh9NLuFFqwNNVwbzBAZy/nEF0ZKhFr3U3lYJuwR50C67oVWIwGrlSUM7xzBJOZOn4+VoxucW178wg/U6EEKJhLKl2ndHPX67bRLOVJjvvCWFXkpQSQMUFiaVv5oK9XJjU048nevjyS3oJ350tZM8lLeevl/HegetsSLlObGRF9VTPUA/2Xiq+pRJLBWeypA+MEE0gQN10zc533OwNde8dXtzZWk2rEiPtQjxQNuBNjFKhIMLXlQhfV0Z39Cb5QhF//Sm7zvutP5TLqA7e3NnaQ/reCSFEPdRUOQ/g66FkQLjaTpEJYXuVO+/J0j0h7EOSUqLBlAoFfVqr6dNaTYFOT9KFIr47W8jFvDKSL2pJvqjF10NJfknVCgfpAyOE7QVoKqb4nOJymz5OfomevZcrekGNbO9l9eNb2sfkXG4Z7+7PBSDM24W+YWrubO1Bj1APPCzofScVnUKIluz2ynlPNwV/351NfomBH84XMbKD9ed3IRxB5c57kpQSwj4kKSWswsddxYOdfRgX7c3Z3FK+O1tI0oXCahNSt5I+MELYTuUOfLaulEq6UES5Adr7u3GHvxsGQ+2v+/qypN+Jn4eSB6K9OXytYsnf1RvlXD11g69O3cBFCd2DPbgzTM2dYR5E+bqiUNS2s59UdAohWqbbK+cf6ebHhkPX2Xwsn2F3eFbZFVWI5kB23hPCvmTbNGFVCoWCjgHuxMUE8Ke7g+ocX9kHRoj6Wr16NW3btsXDw4OYmBj2799f6/jPPvuMzp074+HhQY8ePfjmm2/Mfv7qq6/SuXNnPD09adWqFSNGjGDfvn1mY9q2bYtCoTD7euONN6z+3KwlsAmSUkajke/OVSzds0WVFPzW76Q2LwwI4IkefrwxMpTExyJYOCSI0R29CPZUUW6o6Hm14dB14r++xrStV/jHnhx+TC2iUKdnd5qW5buyqiS9Kis6d6dpbfK8hBDC0Y3t5IWfh5KMwnJ+OF9o73CEsDqj0fhbUkoqpYSwC0lKCZspKjVaNO6fR/P4Jb0YvcGy8UJs3ryZuXPnsmTJEg4dOkSvXr0YNWoUmZmZ1Y7fvXs3EydO5Nlnn+Xnn39mwoQJTJgwgWPHjpnGdOrUiXfeeYejR4/y448/0rZtW0aOHElWlnnj19dff51r166ZvmbNmmXT59oYv1VK2W753umcUlLzynBVwj1tbVdRVNnvpDLRVilQo6qyDNjTTUlspIb4mADWT2jDmnFhTO/Xir5hHripFORo9Xx3rpA3/pvNxM8u85cfa27uC/+/vTuPb6pO9wf+SdI2S/eFbnSFQtlRWToFhkV2vAiIKIKCy4DObZHl/nQEQUQGi87I1REs4gByr/SCOOCCI1irBZG9WEsRimxtBdrSvU3atE3O74+0kdgt3XJy2s/79eoLcnLOyZMGniTP+X6fr2lEJ/MTEXVFKgc5ZvdzBwDsPV+CGuZC6mTydQZUcOU9IlFx+h51GGv7wJzP1eN8bh681AqMCtVgTJgzens71ZteQ1Rn06ZNWLRoEZ566ikAwNatW/Hll19ix44deOmll+rt/84772DKlCl44YUXAADr169HYmIiNm/ejK1btwIA5s2bV+8xtm/fjrS0NIwfP9683dXVFf7+/h311NqVt7qup5QBgiB0yP+pxNpRUiNCNPVW3Wxv1qwU+nuyu5qmz+jjBn2NEel5epy7VYFztyuRXVKNmmZmG3JlPyLqyqb2dsG/fi5BrtaApKvlmNzLVeyQiNoNV94jEh+LUtRhrOkD4640rehyIrsChRUGfH6pDJ9fKoO/iwPGhGkwOswZoR5ONoya7F1VVRVSUlKwcuVK8za5XI4JEybgxIkTDR5z4sQJrFixwmLb5MmT8emnnzb6GNu2bYO7uzsGDx5scd/GjRuxfv16hISEYN68eVi+fDkcHBpOpXq9Hnr9b9NTS0tLAQBGo7HZvkt197elP5O70vThqsYIFFfUwF3VvkUjfY0RR29oAQATejjXi7m9e0sBgAzAAN+7c4IAYwuu3DvKgXv9lbjXX4lnABzMKMO2lOJmj8vXVsNotP9c1JG/+45mL7GL/fhE9kblIMfD/d3xz5QifJxegvt7uPDLO3UamVx5j0h0LEpRh6nrA/P60canxsREeWNEiAb/OVzAudsVOHpDi5PZFcgpr8He9FLsTS9FmIcjRoc5Y3SYBv4u9d8wDEahRSMnSNry8/NhMBjg5+dnsd3Pzw+XLl1q8JicnJwG98/JybHYdvDgQcydOxc6nQ4BAQFITEyEj4+P+f7nn38e9913H7y8vHD8+HGsXLkSt2/fxqZNmxp83Li4OKxbt67e9szMTGg01k11y8zMtGq/xrg4KlBeLUPalSwEObfpVPWcviODrloBb6UAF91tXL9ueX9bY7cFpwoZgOaLde+dLsCZa/m418eIcFfA3lOMFH73jRE7dp2OPcSIfm9KLxd8cqF2tNS1ckzhaKlOIT4+HvHx8bhx4wYAoH///njllVcwdepUAMDYsWNx5MgRi2OeffZZ8yjzhjQ2KvvNN980j1gPCwurl+vj4uIaHO3e0bK58h6R6FiUog5V1wfmt1WtTH6/qpWjQoaoIA2igjSorDHi1K+mAlXKrQrcKK7GjdRi/E9qMSJ9nDAmzBl/DHWGp1rxuxWzGj43kbXGjRuH1NRU5Ofn44MPPsAjjzyCU6dOwdfXFwAsRlsNGjQITk5OePbZZxEXFwelUlnvfCtXrrQ4prS0FMHBwQgNDYWLS9NNwY1GIzIzMxEaGgq5vPXt/3wv5aC8qBoqT3+Ed1e3+jwN2XY1D4AeUyLd0bOHu3l7e8VuCyFGAf9343aTzeBlACoNMnyfK8P3uXL4aBT4Y6gGfwzVoKdn/ZX8xCSl3/3v2Uvs5eVs5kz0eyoHOeb0d8cHtaOlxnO0VKcQFBSEjRs3olevXhAEAbt27cKMGTPw448/on///gCARYsW4bXXXjMf09xFtdu3b1vc/uqrr/DMM89g9uzZFttfe+01LFq0yHzb1VWcQmfd9L1QrrxHJBoWpajD1fWBSc+tQEZWDiJD/DHAT93oaCaVgxxjwpwxJszZtDJWtg5HbuhwPrcSGflVyMivwj9TihDs7mgecnu3uhWzft/8mDoHHx8fKBQK5ObmWmzPzc1ttNeTv7+/Vfs7OzsjIiICERER+MMf/oBevXph+/btFlMF7xYVFYWamhrcuHEDkZGR9e5XKpUNFqvkcrnVX7pbsm9DvDUOuFZUjaJKY7t+0b9ZWo0LeXrIAEzo6drgudsauy3I5cCzzYzofPGPPtA4ynHkhhYnsnXI1xlw4GIZDlwsQ6Crg2kkZ6gGIXY01VgKv/vGiB27VH9vRB3NNFqqFHkcLdVpTJ8+3eL2hg0bEB8fj5MnT5qLUhqNpkW9NH+/72effYZx48ahR48eFtvtoUfn3SvvBXOkFJFoWJQim1DIZRjop4KLTkC4nwpyK+e+uCgVmBThikkRriiqMOD7TC2O3NAiI7+qwYLU3badLURUUOPFL5ImJycnDBkyBElJSZg5cyYA0wiLpKQkxMbGNnhMdHQ0kpKSsGzZMvO2xMREREdHN/lYRqPRoifU76WmpkIul5tHUtmj31bga3wkUGt8U9vg/L5AFbo5S/utxNoRnUMC1agyCDh70zSS8/TNCtwqq8Ge8yXYc77kt6nGoRr4N7CCD6caE5GUKR3keHiAGz44W4S9HC3V6RgMBuzbtw9ardbi89Hu3bvx0Ucfwd/fH9OnT8eaNWusbkGQm5uLL7/8Ert27ap3X0t6dAKt79PZVL/CO9oa88p7/s4Ku+wpaC/9FluDsYvHXuK39vGl/U2CuhRPtQIP9nHDg33ckHy9HH//oaDJ/bliVue1YsUKLFy4EEOHDsXw4cPx9ttvQ6vVmlfjW7BgAbp37464uDgAwNKlSzFmzBi89dZbeOCBB7Bnzx6cPXsW27ZtAwBotVps2LABDz74IAICApCfn48tW7bg5s2bmDNnDgBTs/RTp05h3LhxcHV1xYkTJ7B8+XI8/vjj8PT0FOcXYQVvdfsXpQxGAUnXTA3OJ/ZsehqiVFg7otNJIcOIEA1GhGigqzbi9K8VOHJDix9v159qPDrUGaNCNfDWOHCqMRF1ClMiXPCvC6W4w9FSncb58+cRHR2NyspKuLi44MCBA+jXrx8A08rEoaGhCAwMRFpaGv7yl78gIyMD+/fvt+rcu3btgqurKx566CGL7S3t0Qm0vU9nQ/0KLxaZ+kp2Uwn4NetGs+cQk9j9FtuCsYtH7Pit7dPJohRJkgzWXZkrqmjf0SFkHx599FHcuXMHr7zyCnJycnDPPffg0KFD5mbmWVlZFlNwRowYgYSEBKxevRqrVq1Cr1698Omnn2LAgAEAAIVCgUuXLmHXrl3Iz8+Ht7c3hg0bhu+//948fF2pVGLPnj149dVXodfrER4ejuXLl9db1c/eeGtMab6goqbdzplyy7RapptSjqigzlNQaemITo2jHGPDnTE23BllegNONDrV2AFZJfV//5xqTERSo3SQ4+H+btjG0VKdRmRkJFJTU1FSUoJPPvkECxcuxJEjR9CvXz8sXrzYvN/AgQMREBCA8ePH4+rVq+jZs2ez596xYwfmz58PlcryAnFLe3QCre/T2VS/wtTKUgAl6NlNg/Bwn4ZPIDJ76bfYGoxdPPYSv7V9OlmUIknyVFu3tL21+5H0xMbGNjpdLzk5ud62OXPmmEc9/Z5KpWr2qt99992HkydPtjhOsXXE9L2va6fujQt35peRWq6/m2p8LEuLozd0uHhH32BB6m6catw1xcXFYf/+/bh06RLUajVGjBiBN954o8H+dHd7++23ER8fj6ysLPj4+ODhhx9GXFyc+Utfc6tpEbXV5AhTb6k7WgO+uVqOqb05WkrKnJycEBERAQAYMmQIzpw5g3feeQfvv/9+vX2joqIAAFeuXGm2KPX9998jIyMDe/fubTaG5np0Am3v09nQftmlpvfnEHcnuy88iN1vsS0Yu3jEjt/qHrodHAdRh+jvq4SPpumCk1wGeKj4T5y6tvYuShVVGHDm1woAwMSIzjF1r715qhWYHumGv032x4sjm7/yWjfVmLqWI0eOICYmBidPnkRiYiKqq6sxadIkaLXaRo9JSEjASy+9hLVr1+LixYvYvn079u7di1WrVpn3qVtNKyUlBWfPnsX999+PGTNm4MKFC7Z4WtQF1I2WAoCP00tQbRBEjojaU1P9NFNTUwEAAQEBzZ5n+/btGDJkCAYPHtzsvmL16MzmyntEdoEjpUiSFHIZFjezYpZRAF5KzMXacb6I9Gl4KDBRZ+dTO1qwrMoIfY0RSoe2FWq/vVYOgwD09nZCmB2tNmevrP2qxqnGXc+hQ4csbn/44Yfw9fVFSkoKRo8e3eAxx48fx8iRIzFv3jwAQFhYGB577DGcOnXKvI81q2kRtdWUXq6m0VI6AxKvlmMaR0tJ0sqVKzF16lSEhISgrKwMCQkJSE5OxuHDh3H16lUkJCRg2rRp8Pb2RlpaGpYvX47Ro0dj0KBB5nP06dMHcXFxmDVrlnlbaWkp9u3bh7feeqveY9pLj867V94L4cp7RKJiUYokq6kVsx4f7IF/Xy7D5YIqrErMxcrR3TC0u1rEaInE4ewkh1Ihg94goLDCgADX1helBEFAYu3UvUkcJWUVa6cQGwSONOjqSkpKAABeXl6N7jNixAh89NFHOH36NIYPH45r167h3//+N5544okG929sNa27tXZFq7p97v5TSqQcOyB+/A4y4OF+rtiWUoyP00swPlxj9XRusWNvC3uKvT1iyMvLw4IFC3D79m24u7tj0KBBOHz4MCZOnIjs7Gx888035sVkgoODMXv2bKxevdriHBkZGeb8VWfPnj0QBAGPPfZYvce0lx6dd3QG88p7AQ2smEtEtsOiFEla3YpZDS2zPjJEg7ijd3DudiVeS87D0j94Y3wnWSmMyFoymQxeGgVul9WgQGdo0wevS/l6/FpaA6VChtGhzu0YZedVN9U4v5npk++eLECBzoBZ/dzgwN5SXY7RaMSyZcswcuRI8wIMDZk3bx7y8/MxatQoCIKAmpoaPPfccxbT94CmV9P6vbauaFW3r1RJOXZA3Ph7OwDujqb8tud0Jkb5t6y4LuXfvT3Ebu2qVk3Zvn17o/cFBwfjyJEjzZ5DaOCiyuLFiy2apN/NXnp0ZhWbRkl1d3Nkf0wikbEoRZKnkMswyF9Vb7vaUY5XxvninRMF+O66Fv99ogBFlQbM7ucGmYxvPtR1eKt/K0q1xddXTKOkRoVqoHFivzZrWDPVONzDEdeLq7ErtRhHM7V4/g/e6OXNKcddSUxMDNLT03Hs2LEm90tOTsbrr7+O9957D1FRUbhy5QqWLl2K9evXY82aNeb9mlpN6/dau6IVYD+r+7SGlGMH7Cf+R2vKsC2lGN/lOmHu8ACrvtzbS+ytYU+xW7uqFTWMU/eI7AeLUtSpOchlWD7CG55qBfb/XIoPfyxGUYUBzwzxhJyFKeoizM3OK5peBa4pumojvs80XZVlg/OWaWqq8eKhXogOVuO761p8cLYI14uq8V+HcvBgH1c8PtgDqjb2ACP7Fxsbi4MHD+Lo0aMICgpqct81a9bgiSeewJ/+9CcApiXatVotFi9ejJdfftn8Jbklq2m1dUWrlu5rb6QcOyB+/FN6u+FfF8uQrzPgm2s6PBBpfW8psWNvC3uIXezHl7qskioAQAibnBOJjkUp6vTkMhmevs8TnioFtp8rwmeXylBcacCyaB8O16UuwVtjSvVtGSl1LFOLyhoBga4O6N+No3haqqmpxgBwfw8X3BeoxgdnC3Hkhg6fXizDiSwdYqK8cV8g++F1RoIgYMmSJThw4ACSk5MRHh7e7DE6na7eF1GFQmE+X2OaWk2LqC2cFDLM6e+OrWcK8fGFEkyKcOFnK5KEuul7HClFJD4WpajLmNXPDR5qOd4+XoAjN3QoqczDqjHdoHHklSbq3HzqRkq1oSiVeNW0TP3Eni6c/tpKjU01ruOhUuCFUd0wLrwCW04XIFdrwCvf5mFcuDP+NMQT7irrmqaTNMTExCAhIQGfffYZXF1dkZOTAwBwd3eHWm0qRC5YsADdu3dHXFwcANPKeps2bcK9995rnr63Zs0aTJ8+3Vycamo1LaKOMDnCBfsulKBAZ8DhK+X4jxaMliISgyAIyOb0PSK7waIUdSnjwl3grlTg9aN3kJpTiZWJuXh1nK/VK2QRSVHd9L3mmm03JrukGhfv6CGXAeN7sMF5RxvaXY33/iMQ//tTMb64VIbvrmuRcqsCi4d6YUyYhkXBTiI+Ph4AMHbsWIvtO3fuxJNPPgkAyMrKshgZtXr1ashkMqxevRo3b95Et27dMH36dGzYsMG8T1OraRF1BEeFDI/0d0f8mULsqx0t5cTRUmTH7ugMqKgR4CAHAt1YlCISG4tS1OXcF6jG6xP8sO67PFwtrMKLh3Pw2nhfLgdLnZa3unb6Xit7SiXWNjgfGqiGl4ZvG7agdpTXFqGc8Y+TBcgsrsbff8jHd9dViBnuDV8Xvg5S19R0uzrJyckWtx0cHLB27VqsXbu20WOaWk2LqKNMqh0tla8z4PCVMkyPdBM7JKJG1U3dC3R15Iq3RHaA85aoS+rto8Sbk/3h5+KA2+U1eOFwDq4UsN8GdU51I6UKdQYYrfgifLcao4Bvr5uKUpPY4NzmIn2UeHtqAJ4Y7AEHOZByqxL/efAWPrtUCoOxZa8lEVFHcVTI8MgAdwDAvvRSVBmYn8h+mZucc+oekV1oUVEqLi4Ow4YNg6urK3x9fTFz5kxkZGQ0eczYsWMhk8nq/TzwwAMW+128eBEPPvgg3N3d4ezsjGHDhiErK6vlz4jISt3dHPH3yf7o4emI4kojVibmIvV2hdhhEbU7T7UCMgAGASipNLbo2NO/VqC40ggPlRxDu7PhthgcFTI8OtAd7z4QiP6+SlTWCPjgbBFeOJyDG0VV5v0MRgHncyuRki/D+dxKFq2IyKYm9nRBN40ChRWm0VJE9iqrrp8UV94jsgstKkodOXIEMTExOHnyJBITE1FdXY1JkyZBq9U2esz+/ftx+/Zt8096ejoUCgXmzJlj3ufq1asYNWoU+vTpg+TkZKSlpWHNmjVQqRpvCEvUHjzVCmyc6I9BfkpU1Ah49bs8HLnR+L9nIilykMvgoaprdt6yKXyJV02jpO7v4cIh7iILdndE3EQ/xAz3gsZRhssFVVj679v439QiHL2hxTOf3sTLSXfwP78o8HLSHTzz6U0cz9KJHTYRdRGOChnmcLQUSQBX3iOyLy1qSnHo0CGL2x9++CF8fX2RkpKC0aNHN3iMl5eXxe09e/ZAo9FYFKVefvllTJs2DW+++aZ5W8+ePVsSGlGraZzkWHe/HzYdz8f3mTr87Vg+SioNeLAP+yFQ5+GtUaCo0oCCCgMirDymQFeDlFum0YMTe3Lqnj2Qy2SY2tsVw4PU2HqmECeyK7A3vbTBffN1Brx+9A5Wje6GESEaG0dKRF3RxJ4u2Jdegjs6Aw7/Uobp/CxFdoYr7xHZnzZ1Si0pKQFQv/DUlO3bt2Pu3Llwdjat4GQ0GvHll1/ixRdfxOTJk/Hjjz8iPDwcK1euxMyZMxs8h16vh17/W/+f0tJS87mMxqanptTd39x+9kjKsQP2Hb9CBvzXCC+4KeX48nI5tp0tQoGuBgsGu8MoAOm5lfglX4ZSVQUG+KmgkNCIEXv6vdtDDF2Vt0aBK4VAQQtW4Eu6poVRAPp1UyKYH9zsirfGAS+P8cWxTC3e+D4fTY1H2Ha2EFFBaknlLSKSprreUltOF2LfhVJMinCB0oEtbMl+3NFy5T0ie9PqopTRaMSyZcswcuRIDBgwwKpjTp8+jfT0dIuVYfLy8lBeXo6NGzfir3/9K9544w0cOnQIDz30EL777juMGTOm3nni4uKwbt26etszMzOh0Vh3NTgzM9Oq/eyRlGMH7Dv+iV4AgmX4MluBf/1chp9+LcGdShlKqmQAFMAv+fBwEvBQmBGDvaU1LN0efu86HacSiaWu2bm1RSlBEMxT9yaywbndclMqmixIAaYRUxfy9BjkzynxRNTxJvR0wccXSnBHa8DhK+UceU52pa6fFFfeI7IfrS5KxcTEID09HceOHbP6mO3bt2PgwIEYPny4eVvdyIkZM2Zg+fLlAIB77rkHx48fx9atWxssSq1cuRIrVqww3y4tLUVwcDBCQ0Ph4tL0lyej0YjMzEyEhoZCLpfWlRspxw5IJ/5newA9rpZj86kiXCmtH2dxlQw7Livw0h+9MSLY/qfE2NPvvby8XNTH78q81aZ0X1BhXU+p9Dw9bpfVQO0gwyhO/bJbRRXWFRnjTxdgQk8XDAlUI9TDETIZP4gTUcdwVMjw6AB3bD5ViH3ppZjM0VJkR+pW3gtlk3Miu9GqolRsbCwOHjyIo0ePIigoyKpjtFot9uzZg9dee81iu4+PDxwcHNCvXz+L7X379m204KVUKqFUKuttl8vlVn/pbsm+9kbKsQPSiH9CT1d8mFqCMn3j083+mVKM6GBnyUyJsYffu9iP35W1dKTU11dMBcQ/hjlD7cjXzV55qhVW7ZddWoOdPxZj54/F8NYoMCRAjSHdVbjHXw1np+ZfX4NRwIU8PYoqDPBUK9DfVymZ3EdEtje+hwv2pptGSx26Uo4ZHC1FdqKuyTnbEhDZjxYVpQRBwJIlS3DgwAEkJycjPDzc6mP37dsHvV6Pxx9/3GK7k5MThg0bhoyMDIvtly9fRmhoaEvCI2o3F/L0TRakAE6JIWlpSVFKW2U0r9rGBuf2rb+vEj4aBfKbeF091XI83M8N525X4nyuHgU6A76+Wo6vr5ZDLgP6dlNiSKAaQwLV6OFZfxTV8Swdtp0ttHgMH40Ci4d6sYE6ETXo7tFSn6SXYgpHS5GdyGKTcyK706KiVExMDBISEvDZZ5/B1dUVOTk5AAB3d3eo1WoAwIIFC9C9e3fExcVZHLt9+3bMnDkT3t7e9c77wgsv4NFHH8Xo0aMxbtw4HDp0CF988QWSk5Nb+bSI2sbaKTHW7kckNu/aETUFVvybPXpDC71BQLC7I/r4OHV0aNQGCrkMi4d64fWjdxrd58/DvDEiRIMZfd2hrzEiPU+PlFsVOHerAr+W1uBCnh4X8vT4n9RieKoUuC9QhSGBatwboML5XH2D5+bKfkTUnPE9XPBxegnytAYc+qUcM/pytBSJ6+6V90I9+PmGyF60qCgVHx8PABg7dqzF9p07d+LJJ58EAGRlZdWbopORkYFjx47h66+/bvC8s2bNwtatWxEXF4fnn38ekZGR+Ne//oVRo0a1JDyidmPtlBhPNa/6kTR4a0zpXltlRGWNEaomrlh/XdfgvKcLew9JwIgQDVaN7mbVaCalg9w8KgoAcsqrce5WJc7erEBabiWKKg1IuqZF0jUtZAAUzaS49lrZz2AUkJ5biYx8Gco1lRjg136rBXLqIZE46lbi23yqEJ9cKMWUXhwtReK6e+W9ANc2LUJPRO2oxdP3mtPQ6KbIyMhmj3366afx9NNPtyQcog5jzZQYAPg4vQTdnB0Q4MohwGTfNI4yqBxkqKwRUKAzoLtbw18MbhRV4ZeCKihkwP09nG0cJbXWiBANooLUSM+tQEZWDiJD/K0q7Pi7OGJab0dM6+2KaoOAC3mVSLlViZRbFcgqqUZN07OYka8zIPm6FtHBGqgdZa0qYlpOD1QAv9xpt+mBnHpIJK7xPVywL70EuVoDvvqlHDM5WopElMmV94jsEkvERA2wZkqMQgak5ugRc/A2Hhvojln93PgGR3ZLJpPBW63AzbKa2qJUw4XUulFSUUEaeKisGzFI9kEhl2GgnwouOgHhfirIW5iPHBUy3BOgxj0BajwzxBOfXyrFtrNFzR733ycK8N8nCqBykMFLrYCXWgFvjQJeagfTbY0C3rV/eqkVFqP0jmfpOmx6YEeem4isUzda6t1ThfjkQgmm9HKBFWsrEHWIbK68R2SXWJQiakRzU2JCPRyx5XQh0nIqsSu1GMk3tIiN8kbfbvVXhiSyB96a2qJURU2D91cbBHx3TQsAmBjBBuddXZiV/TZUCqDSAFTWCLhVVoNbZQ3/+6rj7CiDl8YBnio5MvKrmtx3y6kCaBxlpoK/DJDDVGCtvQlZ7Z9ymcz099p9BADvnS5o8tztNfWQiJo2vqept1Su1oCvLpdjRh++v5A46lbeY5NzIvvCohRRE5qbErNhvC++va7F9pQiZBZX48XDOZja2wUL7vGECy8Fkp0x9ZXSN7oC36lfdSirMsJLrcB9AVxVsquzZhqzj0aB7TO7o9oooLDCgEKdAQW1fxZWGFBYUWOxvbJGgLZagLakGtklzcdQojdidVJeOz6r33AFVSLbcJDL8OhAd/zjZCE+uVCMYDcFrnVA/zii5tRN3wtmUYrIrrAoRdSMpqbEyGQyjO/hgqGBauw8V4Rvrmnx78vlOJFVgWeHeWJkiIaNoslueGtqV+BrpMjw9RXT1L0JPZ35JYGsmsa8eKgXFHIZFHIZAl3lCGymv56u2mguWB3LMuXL5nirFVA7yiAIphFQggAYYepz+dvfa38gwCgAVTUCKg3N98HkCqpEtnF/DxfsSi1GSaURrybno737xxE1x8iV94jsFodyELUDd5UCy0b44PUJfgh0dUBRpQEbv8/Ha8l3kFfe9FQWIltpqiiVp63Bj7crAZhW3SMCfpvG7KOx7C/mo1G0qieTxlGOIHdHDPJXYVSIdY30/2ukD7Y+2B3vz+iObTO644OZ3bF9ZnfsmBWEnQ8FYddDQfif2UH434eD8NHDwUiYE4xXxvladW5rV1olorY5/WsFSirrr5xQ1+PteJZOhKgoPj4egwYNgpubG9zc3BAdHY2vvvrKfP/YsWMhk8ksfp577rkmz/nkk0/WO2bKlCkW+xQWFmL+/Plwc3ODh4cHnnnmGZSXN3+Roi3ydabRulx5j8j+8H8kUTsa5K/C5v8IxL70Euy7UIIzNyuQlnML8wd7YEYfV44+IVF5q00pv6GeUklXyyEAGOin5GqSZKFuGvOFPD2KKgzwVCvQ31fZ5nxm7fTA/r4t79PXkecmopYxGAVsO1vY5D7s8SaOoKAgbNy4Eb169YIgCNi1axdmzJiBH3/8Ef379wcALFq0CK+99pr5GI2m+YsRU6ZMwc6dO823lUrLXDt//nzcvn0biYmJqK6uxlNPPYXFixcjISGhnZ5ZfXX9pLq7ceU9InvDohRRO3NSyDB/sAdGhzlj86kCXMjTY8e5IiRfL0dslDd6+/BLEImjsZFSRkHAN7Wr7k3iKClqgEIua/feSy2ZHmhP5yailrmQp2+yQAywx5tYpk+fbnF7w4YNiI+Px8mTJ81FKY1GA39//xadV6lUNnrMxYsXcejQIZw5cwZDhw4FALz77ruYNm0a/v73vyMwMLAVz6R5WSVsck5kr1iUIuogwe6OiJvoh2+ulmPHuWJcK6rG/zucgwd6u+KJezygcTTNnjUYhXYfgUDUkLqiVGGFAQajYP53lpZTiVytARpHGaLZ14NsqLlVTtvSZ6Yjz01E1rO2dxt7vInLYDBg37590Gq1iI6ONm/fvXs3PvroI/j7+2P69OlYs2ZNs6OlkpOT4evrC09PT9x///3461//Cm9vbwDAiRMn4OHhYS5IAcCECRMgl8tx6tQpzJo1q8Fz6vV66PV68+3S0lIAgNFohNFYf2ponbr76opSwW4OTe5vb+pilVLMdRi7eOwlfmsfn0Upog4kl8kwKcIVw4M0+OfZIiTf0OKLjDIcz9bhuWFeEATwCxPZjKdKAbkMMApASaUBXhrTW0Bi7SipMWHOUDmw1SDZVnOrnLbHuVn4JxKPtb3brhTqMSpUw/+fNnb+/HlER0ejsrISLi4uOHDgAPr16wcAmDdvHkJDQxEYGIi0tDT85S9/QUZGBvbv39/o+aZMmYKHHnoI4eHhuHr1KlatWoWpU6fixIkTUCgUyMnJga+vZd8/BwcHeHl5IScnp9HzxsXFYd26dfW2Z2ZmWjWl8EqeFoAMSn0Rrl9vejqpPcrMzBQ7hFZj7OIRO36dzrp+gSxKEdmAh0qB/zfKB/f3cMZ7pwuRU16DDUcanlZS1/SzNU2EiZqikMvgoVKgsMKAggpTUapcbzA3mJ0Uwal7JI6mVjltj3NzShCReKzp8QYABy6W4czNCiy81xN/CFJz9WIbiYyMRGpqKkpKSvDJJ59g4cKFOHLkCPr164fFixeb9xs4cCACAgIwfvx4XL16FT179mzwfHPnzrU4ZtCgQejZsyeSk5Mxfvz4Vse5cuVKrFixwny7tLQUwcHBCA0NhYtL459fjEYjrt/IRJ5eDkDA0F7dESyhKXxGoxGZmZkIDQ2FXC6tC4eMXTz2Er+1CxiwKEVkQ/cFqrHlPwLwf2nF+OTnsib3ZdNP6gjemtqilM6AXt7Adze0qDYCYR6OiPDiEslERNS+rOnxNqGHM07frMCvpaaLdn18lHjyPg8M8GVBuaM5OTkhIiICADBkyBCcOXMG77zzDt5///16+0ZFRQEArly50mhR6vd69OgBHx8fXLlyBePHj4e/vz/y8vIs9qmpqUFhYWGTvauUSmW9hukAIJfLm/3SXaSHeeW97u5O7Xrhw1aseZ72irGLR+z4rX1s6f6GiSRK6SDHfYHNj4Cqa/pJ1J5+3+w88Uptg/MIF16VJrKhuLg4DBs2DK6urvD19cXMmTORkZHR7HFvv/02IiMjoVarERwcjOXLl6OysrLN5yXqSHU93nw0llP5fDQKrBrdDctG+OCDGd3x6AB3KBUyXMrX46Wvc7HuuzzcKK4SKequyWg0WvRuultqaioAICAgwOrz/frrrygoKDAfEx0djeLiYqSkpJj3+fbbb2E0Gs1Fr/aWU2H6fMOV94jsE0dKEYnA2mae758pxKhQDQb4qdDb2wlK9vuhNvJWm9J+QUUNrhToca2oGg5yYGy4s8iREXUtR44cQUxMDIYNG4aamhqsWrUKkyZNws8//wxn54b/PyYkJOCll17Cjh07MGLECFy+fBlPPvkkZDIZNm3a1OrzEtlCc/3jnJ3keOIeDzzQ2wX/d74Eh6+U48zNCpy9WYH7ezhj/iAP+Lrwq0t7WrlyJaZOnYqQkBCUlZUhISEBycnJOHz4MK5evYqEhARMmzYN3t7eSEtLw/LlyzF69GgMGjTIfI4+ffogLi4Os2bNQnl5OdatW4fZs2fD398fV69exYsvvoiIiAhMnjwZANC3b19MmTIFixYtwtatW1FdXY3Y2FjMnTu3w1bey6lta8OV94jsEzM7kQisbfqZWVKNzLQSACVwkAO9vZXo76vEAD8V+voooXFqukhlMApIz61ERr4M5ZrKdmseTNJ190ipxKtaAEB0sAZuSuv+TRJR+zh06JDF7Q8//BC+vr5ISUnB6NGjGzzm+PHjGDlyJObNmwcACAsLw2OPPYZTp0616bxEtmJN/zgvjQNiorwxs68b/je1GMeydEi6psWRG1r8R6QrHhng3infs8RYjTkvLw8LFizA7du34e7ujkGDBuHw4cOYOHEisrOz8c033+Dtt9+GVqtFcHAwZs+ejdWrV1ucIyMjAyUlJQAAhUKBtLQ07Nq1C8XFxQgMDMSkSZOwfv16i6l3u3fvRmxsLMaPHw+5XI7Zs2fjH//4R4c9z7qRUixKEdknFqWIRGBN008PlRyPDnDHz3f0uJCnR2GFAT/f0ePnO3rsu1AKuQzo4elkLlL166aEu+q3D2nHs3R3reynAH65w5X9yFyUul1Wg8za5ZEn9mSDcyKx1X2p8/LyanSfESNG4KOPPsLp06cxfPhwXLt2Df/+97/xxBNPtPq8rV1mvW6fu/+UEinHDkg7fmtjD3BR4MVR3piZ74JdP5XgfK4en14sw9dXyvFQPzc8GOli0xVj6y70/ZIvQ6mqAgP8VO1WNDqercMHKcXmqfWA6f160RAPjAhu+DNbe7z227dvb/S+4OBgHDlypNlzCIJg/rtarcbhw4ebPcbLywsJCQnWBdkObutqi1IeLEoR2SMWpYhEYE3Tz/8c7o0RIRpM72N6w79dXoP0XD0u5FXiQp4eOeU1uFJYhSuFVfjskqlpeoi7Iwb4KeEol5m33a29V/YT46oetY2nyvQB/uc7pi+hPho57glgI1kiMRmNRixbtgwjR47EgAEDGt1v3rx5yM/Px6hRoyAIAmpqavDcc89h1apVrT5vW5dZr9tXqqQcOyDt+K2N3RHAM+HAJS8ZvsiU46YO+OinEnz+czGmBhsR5StAUfvRwygAV0tlKK0G3ByBnm4C2uNjyU8FMuy/IUdxlQymC3358HAS8FCYEYO9hWaPb+7cOy7XFdd+C7ZAV4ON3+fj6d4NP4a1S613ZQajgLScCtyq/VUFubEoRWSPWJQiEkld08/fRjOZNDSaSSaTIdDVEYGujpgUYRrVkq+twYU8PdJri1RZJdXmn+a8f6YQw7ur4KBo/RVGy5FYjcdO9uN4lg7vnS6w2KatFnAyu4KvGZGIYmJikJ6ejmPHjjW5X3JyMl5//XW89957iIqKwpUrV7B06VKsX78ea9asadV5W7vMOmA/S063hpRjB6Qdf2tj7wFgyj0Cjt7Q4aO0EuRpDdh7TYFjdxzwxGB3AMAH51o22sgax7N12HG5oN724ioZdlxW4KU/erf6/AajgNd+ug2goZHzpgLV5786Yfp9AfUu+lm71HpXZfk51fS7e+XbPDzLz6lEdodFKSIR1TX9bM1oIx9nB4wJd8CY2gbVJZWm1fqOXC/HD9kVTR5bUGHAQ3uy4aFSwE0ph5tSDnfz3+/6U3X3bbm50frxLF2Do7zaeyQWtZ/GXrOKaoGvGZGIYmNjcfDgQRw9ehRBQUFN7rtmzRo88cQT+NOf/gQAGDhwILRaLRYvXoyXX37Z4gu+tedtyzLrrdnX3kg5dkDa8bcmdjmA+3u64o9hLvjqlzLsOV+Cm2U12HisftEIMPVP3Ph9AVaNllv9HicIAmqMQJVBgN5gxPtniprcf/OpIhRWGFFjFKCvEVBlEGqPrf17zV1/N982osogQFtlhLa66ZFW+ToDLuZXY5C/5ahmqb7uttDYZ54Cfk4lskssShGJTCGX1fug0RruKgVGhGhQbRCaLUoBpiHuhRUGFFq5EiAAqBxkcHWSobCi6T4G284WIiqITdXthcEoYNvZwib34WtGZFuCIGDJkiU4cOAAkpOTER4e3uwxOp2u3hdRhUJhPl9rz0skNY4KGR7s44YJPVzwr59LsDe9tMn9//5DPgZfUaJGMBWbqmsLRNUGAdVGwXJbC1s1lVcZse1s04WrtrJ21WbiZx4iKWJRiqiTsXZlv7+M8kGgmyNK9QaUVBpRqjegVF/7p8Vt099rjEBljYDKmuZ7J+TrTKO22qPYRm13IU/fZFN9gK8Zka3FxMQgISEBn332GVxdXZGTkwMAcHd3h1qtBgAsWLAA3bt3R1xcHABg+vTp2LRpE+69917z9L01a9Zg+vTp5uKUNecl6iw0TnIM9lc3W5SqMgg4c6uyw+Lo5e2EIDdHOClkcFLIoHSQ/fb32j+dHGRQKuQW+2QWV+EfJ5suoADWf7YjfuYhkiIWpYg6GWtW9vPRmEZVWXuFSBAE6KoFlOoNSL6uxe60kmaP4VU9+2Hta8HXjMh24uPjAQBjx4612L5z5048+eSTAICsrCyLkVGrV6+GTCbD6tWrcfPmTXTr1g3Tp0/Hhg0bWnReos7E2veuyT2d0d9PBSeFDI61hSFH+W9/b+j2xTuVWPVNXrPnfupez1YVOCK8nJCQVtLsZ7b+vvWn2FLD+JmHSHpYlCLqZKxZ2W/xUK8WDVmWyWRwdpLB2UmO/r4qAM0XpXhVz35Y+1rwNSOynbuXUW9McnKyxW0HBwesXbsWa9eubdN5iToTa9+7xoS7tLhw1N9XZdWFvtYWjTriM1tXx888RNLDDnlEnVDdyn4+Gss3XB+Nos3NHetGYjWFV/XsC18zIiLqrDryPa6uaNSUthaNOvIzW1fEzzxE0sORUkSdVN3Kfum5FcjIykFkiD8G+LW9qSOv6kkPXzMiIuqsOvo9rq5otO1socWIKR+NAouHerVL0agtqzGTJX7mIZIeFqWIOjGFXIaBfiq46ASE+6kgb6c3YFt8QKP2xdeMiIg6q45+j+uoC313a6/VmImfeYikhkUpImoVsa/qbdmyBX/729+Qk5ODwYMH491338Xw4cMb3X/fvn1Ys2YNbty4gV69euGNN97AtGnTzPe/+uqr2LNnD7Kzs+Hk5IQhQ4Zgw4YNiIqKMu9TWFiIJUuW4IsvvoBcLsfs2bPxzjvvwMXFpUOfa3sR+zUjIiLqKB39HtdRF/qoY9iikEhE7YM9pYio1equ6o0Jd8Ygf5XN3uj37t2LFStWYO3atTh37hwGDx6MyZMnIy+v4RVyjh8/jsceewzPPPMMfvzxR8ycORMzZ85Eenq6eZ/evXtj8+bNOH/+PI4dO4awsDBMmjQJd+78Nvx7/vz5uHDhAhITE3Hw4EEcPXoUixcv7vDn257Ees2IiIg6Gt/j6G51hcQhPgIG+vHfA5G9YlGKiCRn06ZNWLRoEZ566in069cPW7duhUajwY4dOxrc/5133sGUKVPwwgsvoG/fvli/fj3uu+8+bN682bzPvHnzMGHCBPTo0QP9+/fHpk2bUFpairS0NADAxYsXcejQIfzzn/9EVFQURo0ahXfffRd79uzBrVu3bPK8iYiIiIiIOhNO3yMiSamqqkJKSgpWrlxp3iaXyzFhwgScOHGiwWNOnDiBFStWWGybPHkyPv3000YfY9u2bXB3d8fgwYPN5/Dw8MDQoUPN+02YMAFyuRynTp3CrFmz6p1Hr9dDr9ebb5eWlgIAjEYjjEZjk8+z7v7m9rNHjF08Uo7fXmIX+/GJiIiIuhIWpYhIUvLz82EwGODn52ex3c/PD5cuXWrwmJycnAb3z8nJsdh28OBBzJ07FzqdDgEBAUhMTISPj4/5HL6+vhb7Ozg4wMvLq9556sTFxWHdunX1tmdmZkKjsa7JZmZmplX72SPGLh4pxy927DqdTtTHJyIiIupKOkVRShAEAIBWq212X6PRCJ1Oh/Lycsjl0pq9KOXYAWnHz9jbR93/0br/s/Zm3LhxSE1NRX5+Pj744AM88sgjOHXqVL1ilLVWrlxpMUKrpKQEISEh8PHxgbOzc5PHGo1GZGdnIzg4WPTXraUYu3ikHL+9xG7veaqj8TOVNEg5fsbePpirrMtV9vSatYaU42fs4rGX+K3NU52iKFVWVgbANJWGiOxfWVkZ3N3dW3Wsj48PFAoFcnNzLbbn5ubC39+/wWP8/f2t2t/Z2RkRERGIiIjAH/7wB/Tq1Qvbt2/HypUr4e/vX6+Rek1NDQoLCxt9XKVSCaVSab5dN31v0qRJ1j1ZIhJNW/KUlPEzFZG0MFcxVxHZu+byVKcoSgUGBiI7Oxuurq6QyZpeVaG0tBTBwcHIzs6Gm5ubjSJsH1KOHZB2/Iy9fQiCgLKyMgQGBrb6HE5OThgyZAiSkpIwc+ZMAKarAUlJSYiNjW3wmOjoaCQlJWHZsmXmbYmJiYiOjm7ysYxGo7knVHR0NIqLi5GSkoIhQ4YAAL799lsYjUZERUVZFTtzlf2TcuyAtOO3l9jbI09JGfOUNEg5fsbePpirrMtV9vSatYaU42fs4rGX+K3NU52iKCWXyxEUFNSiY9zc3CT5DwyQduyAtONn7G3XHlfzVqxYgYULF2Lo0KEYPnw43n77bWi1Wjz11FMAgAULFqB79+6Ii4sDACxduhRjxozBW2+9hQceeAB79uzB2bNnsW3bNgCmoaUbNmzAgw8+iICAAOTn52PLli24efMm5syZAwDo27cvpkyZgkWLFmHr1q2orq5GbGws5s6da/UHQuYq6ZBy7IC047eH2LviqIM6zFPSIuX4GXvbMVdZn6vs5TVrLSnHz9jFYw/xW5OnOkVRioi6lkcffRR37tzBK6+8gpycHNxzzz04dOiQuZl5VlaWxfzpESNGICEhAatXr8aqVavQq1cvfPrppxgwYAAAQKFQ4NKlS9i1axfy8/Ph7e2NYcOG4fvvv0f//v3N59m9ezdiY2Mxfvx4yOVyzJ49G//4xz9s++SJiIiIiIg6CRaliEiSYmNjG52ul5ycXG/bnDlzzKOefk+lUmH//v3NPqaXlxcSEhJaFCcRERERERE1THqt5NtIqVRi7dq1Fs2HpULKsQPSjp+xk61J+XVj7OKRcvxSjr2rkvJrJuXYAWnHz9jJlqT+mkk5fsYuHqnFLxO66jqiREREREREREQkmi43UoqIiIiIiIiIiMTHohQREREREREREdkci1JERERERERERGRzLEoREREREREREZHNdbmi1JYtWxAWFgaVSoWoqCicPn1a7JCaFRcXh2HDhsHV1RW+vr6YOXMmMjIyxA6rVTZu3AiZTIZly5aJHYrVbt68iccffxze3t5Qq9UYOHAgzp49K3ZYzTIYDFizZg3Cw8OhVqvRs2dPrF+/HlzbwP4xT4lParmKeYpsTYp5CuhcuUpqeQpgriLbk2KuYp4SF/OU7XWpotTevXuxYsUKrF27FufOncPgwYMxefJk5OXliR1ak44cOYKYmBicPHkSiYmJqK6uxqRJk6DVasUOrUXOnDmD999/H4MGDRI7FKsVFRVh5MiRcHR0xFdffYWff/4Zb731Fjw9PcUOrVlvvPEG4uPjsXnzZly8eBFvvPEG3nzzTbz77rtih0ZNYJ4Sn9RyFfMU2ZpU8xTQeXKV1PIUwFxFtifVXMU8JR7mKZEIXcjw4cOFmJgY822DwSAEBgYKcXFxIkbVcnl5eQIA4ciRI2KHYrWysjKhV69eQmJiojBmzBhh6dKlYodklb/85S/CqFGjxA6jVR544AHh6aefttj20EMPCfPnzxcpIrIG85S4pJirmKfI1jpLnhIEaeYqKeYpQWCuItvrLLmKecp2mKfE0WVGSlVVVSElJQUTJkwwb5PL5ZgwYQJOnDghYmQtV1JSAgDw8vISORLrxcTE4IEHHrD4/UvB559/jqFDh2LOnDnw9fXFvffeiw8++EDssKwyYsQIJCUl4fLlywCAn376CceOHcPUqVNFjowawzwlPinmKuYpsqXOlKcAaeYqKeYpgLmKbKsz5SrmKdthnhKHg9gB2Ep+fj4MBgP8/Pwstvv5+eHSpUsiRdVyRqMRy5Ytw8iRIzFgwACxw7HKnj17cO7cOZw5c0bsUFrs2rVriI+Px4oVK7Bq1SqcOXMGzz//PJycnLBw4UKxw2vSSy+9hNLSUvTp0wcKhQIGgwEbNmzA/PnzxQ6NGsE8JS6p5irmKbKlzpKnAGnmKqnmKYC5imyrs+Qq5inbYp4SR5cpSnUWMTExSE9Px7Fjx8QOxSrZ2dlYunQpEhMToVKpxA6nxYxGI4YOHYrXX38dAHDvvfciPT0dW7dutfvE9PHHH2P37t1ISEhA//79kZqaimXLliEwMNDuYydpk1qeAqSdq5iniFpHarlKynkKYK4iag3mKdtinhKJ2PMHbUWv1wsKhUI4cOCAxfYFCxYIDz74oDhBtVBMTIwQFBQkXLt2TexQrHbgwAEBgKBQKMw/AASZTCYoFAqhpqZG7BCbFBISIjzzzDMW29577z0hMDBQpIisFxQUJGzevNli2/r164XIyEiRIqLmME+JR8q5inmKbKkz5ClBkGauknKeEgTmKrKtzpCrmKdsj3lKHF2mp5STkxOGDBmCpKQk8zaj0YikpCRER0eLGFnzBEFAbGwsDhw4gG+//Rbh4eFih2S18ePH4/z580hNTTX/DB06FPPnz0dqaioUCoXYITZp5MiR9ZZgvXz5MkJDQ0WKyHo6nQ5yueV/cYVCAaPRKFJE1BzmKfFIOVcxT5EtSTlPAdLOVVLOUwBzFdmWlHMV85R4mKdEIm5NzLb27NkjKJVK4cMPPxR+/vlnYfHixYKHh4eQk5MjdmhN+vOf/yy4u7sLycnJwu3bt80/Op1O7NBaRUorMJw+fVpwcHAQNmzYIPzyyy/C7t27BY1GI3z00Udih9ashQsXCt27dxcOHjwoXL9+Xdi/f7/g4+MjvPjii2KHRk1gnrIfUslVzFNka1LNU4LQ+XKVVPKUIDBXke1JNVcxT4mHeUocXaooJQiC8O677wohISGCk5OTMHz4cOHkyZNih9QsAA3+7Ny5U+zQWkVKiUkQBOGLL74QBgwYICiVSqFPnz7Ctm3bxA7JKqWlpcLSpUuFkJAQQaVSCT169BBefvllQa/Xix0aNYN5yj5IKVcxT5GtSTFPCULny1VSylOCwFxFtifFXMU8JS7mKduTCYIg2G5cFhEREREREREREdBlekoREREREREREZH9YFGKiIiIiIiIiIhsjkUpIiIiIiIiIiKyORaliIiIiIiIiIjI5liUIiIiIiIiIiIim2NRioiIiIiIiIiIbI5FKSIiIiIiIiIisjkWpYiIiIiIiIiIyOZYlKJORyaT4dNPPxU7DCKiRjFPEZEUMFcRkb1jnpI+FqWoXT355JOQyWT1fqZMmSJ2aEREAJiniEgamKuIyN4xT1F7cBA7AOp8pkyZgp07d1psUyqVIkVDRFQf8xQRSQFzFRHZO+YpaiuOlKJ2p1Qq4e/vb/Hj6ekJwDS8Mj4+HlOnToVarUaPHj3wySefWBx//vx53H///VCr1fD29sbixYtRXl5usc+OHTvQv39/KJVKBAQEIDY21uL+/Px8zJo1CxqNBr169cLnn3/esU+aiCSFeYqIpIC5iojsHfMUtRWLUmRza9aswezZs/HTTz9h/vz5mDt3Li5evAgA0Gq1mDx5Mjw9PXHmzBns27cP33zzjUXiiY+PR0xMDBYvXozz58/j888/R0REhMVjrFu3Do888gjS0tIwbdo0zJ8/H4WFhTZ9nkQkXcxTRCQFzFVEZO+Yp6hZAlE7WrhwoaBQKARnZ2eLnw0bNgiCIAgAhOeee87imKioKOHPf/6zIAiCsG3bNsHT01MoLy833//ll18KcrlcyMnJEQRBEAIDA4WXX3650RgACKtXrzbfLi8vFwAIX331Vbs9TyKSLuYpIpIC5ioisnfMU9Qe2FOK2t24ceMQHx9vsc3Ly8v89+joaIv7oqOjkZqaCgC4ePEiBg8eDGdnZ/P9I0eOhNFoREZGBmQyGW7duoXx48c3GcOgQYPMf3d2doabmxvy8vJa+5SIqJNhniIiKWCuIiJ7xzxFbcWiFLU7Z2fnekMq24tarbZqP0dHR4vbMpkMRqOxI0IiIgliniIiKWCuIiJ7xzxFbcWeUmRzJ0+erHe7b9++AIC+ffvip59+glarNd//ww8/QC6XIzIyEq6urggLC0NSUpJNYyairoV5ioikgLmKiOwd8xQ1hyOlqN3p9Xrk5ORYbHNwcICPjw8AYN++fRg6dChGjRqF3bt34/Tp09i+fTsAYP78+Vi7di0WLlyIV199FXfu3MGSJUvwxBNPwM/PDwDw6quv4rnnnoOvry+mTp2KsrIy/PDDD1iyZIltnygRSRbzFBFJAXMVEdk75ilqM7GbWlHnsnDhQgFAvZ/IyEhBEEyN6LZs2SJMnDhRUCqVQlhYmLB3716Lc6SlpQnjxo0TVCqV4OXlJSxatEgoKyuz2Gfr1q1CZGSk4OjoKAQEBAhLliwx3wdAOHDggMX+7u7uws6dOzvkORORtDBPEZEUMFcRkb1jnqL2IBMEQbBN+YvINL/3wIEDmDlzptihEBE1iHmKiKSAuYqI7B3zFFmDPaWIiIiIiIiIiMjmWJQiIiIiIiIiIiKb4/Q9IiIiIiIiIiKyOY6UIiIiIiIiIiIim2NRioiIiIiIiIiIbI5FKSIiIiIiIiIisjkWpYiIiIiIiIiIyOZYlCIiIiIiIiIiIptjUYqIiIiIiIiIiGyORSkiIiIiIiIiIrI5FqWIiIiIiIiIiMjm/j9nt+CH28EqbwAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 1200x300 with 4 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "from pandas import read_csv\n",
-    "from microsplit_reproducibility.notebook_utils.HT_LIF24 import find_recent_metrics, plot_metrics\n",
-    "df = read_csv(find_recent_metrics())\n",
-    "plot_metrics(df)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### You are done here! 👍 Congratulations! 🎉"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "microsplit-reproducibility",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.14"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 4
 }

--- a/examples/2D/HT_LIF24/01_train.ipynb
+++ b/examples/2D/HT_LIF24/01_train.ipynb
@@ -1,747 +1,765 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1:** Training a <nobr>Micro$\\mathbb{S}$plit</nobr> Model"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1:** Training a <nobr>Micro$\\mathbb{S}$plit</nobr> Model"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Introduction - what does this notebook do?"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b>Note:</b> Despite network training arguably being the most important step, the execution of this notebook is optional. If you do not run this notebook, in Step 2 (prediction) we offer you to use pretrained model checkpoints. Like in any respected cooking show: \"we have already prepared someting before the show\"... 😉\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Below, we will train a <nobr>Micro$\\mathbb{S}$plit</nobr> network for unmixing two superimposed channels from our HT-LIF24 dataset. \n",
+        "\n",
+        "This dataset contains four labeled structures, and soon you will be asked to choose which of these two you want to learn to unmix: \n",
+        "1. Cell Nucleui,\n",
+        "1. Microtubules,\n",
+        "1. Nuclear Membrane, and\n",
+        "1. Centromeres/Kinetocores.\n",
+        "\n",
+        "Additionally to four total structures, this dataset also offers acquisitions taken with different exposure times, hence, the data is available at various SNR, i.e. [signal-to-noise ratios](https://en.wikipedia.org/wiki/Signal-to-noise_ratio#:~:text=Signal%2Dto%2Dnoise%20ratio%20(,power%2C%20often%20expressed%20in%20decibels.). Shorter exposure times lead to a collection of fewer photos, which leads to more noise and therefore a lower SNR.\n",
+        "\n",
+        "The lower the SNR of the data you will choose to train <nobr>Micro$\\mathbb{S}$plit</nobr> with, the more important will the unsupervised denoising feature of <nobr>Micro$\\mathbb{S}$plit</nobr> become.\n",
+        "\n",
+        "But enough introduction, let's begin!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Background: what is <nobr>Micro$\\mathbb{S}$plit</nobr> training all about?\n",
+        "Training is done in a supervised way. For every input patch, we have the two corresponding target patches using which we train our MicroSplit. \n",
+        "Besides the primary input patch, we also feed LC inputs to MicroSplit. We introduced LC inputs in [μSplit: efficient image decomposition for microscopy data](https://openaccess.thecvf.com/content/ICCV2023/papers/Ashesh_uSplit_Image_Decomposition_for_Fluorescence_Microscopy_ICCV_2023_paper.pdf), which enabled the network to understand the global spatial context around the input patch.\n",
+        "\n",
+        "To enable unsupervised denoising, we integrated the KL loss formulation and Noise models from our previous work [denoiSplit: a method for joint microscopy image splitting and unsupervised denoising](https://eccv.ecva.net/virtual/2024/poster/2538). \n",
+        "\n",
+        "The loss function for MicroSplit is a weighted average of denoiSplit loss and μSplit loss. For both denoiSplit and μSplit, their loss expression have two terms: KL divergence loss and likelihood loss. For more details, please refer to the respective papers."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Let's do it, let's train a <nobr>Micro$\\mathbb{S}$plit</nobr> Model!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**You are new to Jupyter notebooks?** Don't worry, if you take the time to read all our explanations, we will guide you through them and you will understand a lot. Still, you will likely end up less frustrated, if you do not even start with the ambition to interpret the purpose of every line of code.\n",
+        "Let's start with a nice example, the imports to enable the remainder of this notebook. Ignore it (unless you know what you are doing) and just click **⇧*Shift* + ⏎*Enter*** to execute this (and all other) code cells. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# importing all the things we need further down\n",
+        "import platform\n",
+        "import pooch\n",
+        "from pathlib import Path\n",
+        "from pytorch_lightning import Trainer\n",
+        "from torch.utils.data import DataLoader\n",
+        "from careamics.lightning import VAEModule\n",
+        "\n",
+        "from microsplit_reproducibility.configs.factory import (\n",
+        "    create_algorithm_config,\n",
+        "    get_likelihood_config,\n",
+        "    get_loss_config,\n",
+        "    get_model_config,\n",
+        "    get_optimizer_config,\n",
+        "    get_training_config,\n",
+        "    get_lr_scheduler_config,\n",
+        ")\n",
+        "from microsplit_reproducibility.utils.callbacks import get_callbacks\n",
+        "from microsplit_reproducibility.utils.io import load_checkpoint, load_checkpoint_path\n",
+        "from microsplit_reproducibility.datasets import create_train_val_datasets\n",
+        "from microsplit_reproducibility.utils.utils import (\n",
+        "    plot_training_metrics,\n",
+        "    plot_input_patches,\n",
+        "    plot_training_outputs,\n",
+        ")\n",
+        "\n",
+        "# Dataset specific imports...\n",
+        "from microsplit_reproducibility.configs.parameters.HT_LIF24 import get_microsplit_parameters\n",
+        "from microsplit_reproducibility.configs.data.HT_LIF24 import get_data_configs\n",
+        "from microsplit_reproducibility.datasets.HT_LIF24 import get_train_val_data"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.1:** Data Preparation\n",
+        "\n",
+        "Without any special modifications, **the following few steps will first choose which subset of the *HT_LIF24* dataset to use and then train a <nobr>Micro$\\mathbb{S}$plit</nobr> Model on this data**.\n",
+        "\n",
+        "The reason to pick a subset of the *HT_LIF24* dataset is, that we recorded this data with multiple possible learning tasks in mind. Check the <nobr>Micro$\\mathbb{S}$plit</nobr> paper for all the details.\n",
+        "\n",
+        "This logic you find below will likely also apply to your needs when training on your own data (in case this is what you are after). Still, don't shy away from deviating from the code you find below..."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Select the 2, 3 or 4 channels you want train on, and the exposure time (SNR) of these channel acquisitions you want to use...\n",
+        "To make things more human readable, we use the utility function."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "The next line is likely a bit confusing at first.\n",
+        "\n",
+        "Since the channel unmixing capabilities of <nobr>Micro$\\mathbb{S}$plit</nobr> are trained in a supervised way, we must later feed *(i)* input images that contain certain number of selected structures, and *(ii)* corresponding number of separate channels that show these structures separately.\n",
+        "\n",
+        "The following code cell will help you to select the channels and exposure time you want to train on.\n",
+        "Exposure duration is a parameter of this particular experience and is defined in seconds.\n",
+        "\n",
+        "    VeryLow = \"2ms\"\n",
+        "    Low = \"3ms\"\n",
+        "    Medium = \"5ms\"\n",
+        "    High = \"20ms\"\n",
+        "    VeryHigh = \"500ms\"\n",
+        "\n",
+        "Names of channels follow the following convention:\n",
+        "\n",
+        "    Nucleus = 0\n",
+        "    MicroTubules = 1\n",
+        "    NuclearMembrane = 2\n",
+        "    Centromere = 3\n",
+        "    Input = 11"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from microsplit_reproducibility.notebook_utils.HT_LIF24 import ExposureDuration, define_experiment_config\n",
+        "\n",
+        "CHANNEL_IDX_LIST, TARGET_CHANNEL_IDX_LIST, EXPOSURE_DURATION = define_experiment_config(\n",
+        "    num_channels=2, exposure=ExposureDuration.Medium)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Download the data you need (given your choices from above)\n",
+        "Depending on your internet connection, this will take a while...\n",
+        "\n",
+        "Note that appropriate noise models will only be downloaded if they were not created by executing the notebook `00_noisemodels.ipynb`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "DATA = pooch.create(\n",
+        "    path=\"./data/\",\n",
+        "    base_url=\"https://download.fht.org/jug/msplit/ht_lif24/data/\",\n",
+        "    registry={f\"ht_lif24_{EXPOSURE_DURATION}.zip\": None},\n",
+        ")\n",
+        "\n",
+        "NOISE_MODELS = pooch.create(\n",
+        "    path=f\"./noise_models/{EXPOSURE_DURATION}/\",\n",
+        "    base_url=f\"https://download.fht.org/jug/msplit/ht_lif24/noise_models/{EXPOSURE_DURATION}/\",\n",
+        "    registry={\n",
+        "        f\"noise_model_Ch{channel_idx}.npz\": None\n",
+        "        for channel_idx in TARGET_CHANNEL_IDX_LIST\n",
+        "    },\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Note that the following notebook will download all you need. In case you see no messages announcing any downloads, you already have this data in the notebook folder."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "for fname in NOISE_MODELS.registry:\n",
+        "    NOISE_MODELS.fetch(fname, progressbar=True)\n",
+        "print('---------')\n",
+        "for fname in DATA.registry:\n",
+        "    DATA.fetch(fname, processor=pooch.Unzip(), progressbar=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Next, we load the image data to be processed\n",
+        "\n",
+        "Note that depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> below.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# setting up train, validation, and test data configs\n",
+        "train_data_config, val_data_config, test_data_config = get_data_configs(\n",
+        "    dset_type=EXPOSURE_DURATION, channel_idx_list=CHANNEL_IDX_LIST,\n",
+        ")\n",
+        "# setting up MicroSplit parametrization\n",
+        "experiment_params = get_microsplit_parameters(\n",
+        "    dset_type=EXPOSURE_DURATION, nm_path=NOISE_MODELS.path, channel_idx_list=CHANNEL_IDX_LIST, batch_size=32\n",
+        ")\n",
+        "\n",
+        "# start the download of required files\n",
+        "train_dset, val_dset, _, data_stats = create_train_val_datasets(\n",
+        "    datapath=DATA.path / f\"ht_lif24_{EXPOSURE_DURATION}.zip.unzip/{EXPOSURE_DURATION}\",\n",
+        "    train_config=train_data_config,\n",
+        "    val_config=val_data_config,\n",
+        "    test_config=val_data_config,\n",
+        "    load_data_func=get_train_val_data,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Configure `num_workers`\n",
+        "In Windows and MacOS, setting `num_workers > 0` for dataloaders would cause out-of-memory issue and might crash the system."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def get_num_workers():\n",
+        "    \"\"\"Utility function to set num_workers based on OS.\"\"\"\n",
+        "    if platform.system() == \"Windows\" or platform.system() == \"Darwin\":\n",
+        "        return 0\n",
+        "    else:\n",
+        "        return 3  # or any other number suitable for your system\n",
+        "\n",
+        "experiment_params[\"num_workers\"] = get_num_workers()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "***Optional:*** inspect data configurations and <nobr>Micro$\\mathbb{S}$plit</nobr> config"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "do_show_configs = True\n",
+        "\n",
+        "if do_show_configs:\n",
+        "    print('FYI: train_data_config')\n",
+        "    print('----------------------')\n",
+        "    for cfg in train_data_config:\n",
+        "        print(cfg)\n",
+        "\n",
+        "    print('\\nFYI: experiment_params')\n",
+        "    print('----------------------')\n",
+        "    print(experiment_params)\n",
+        "else:\n",
+        "    print('You opted out of having all params printed... swiftly moving on... ;)')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Wanna trade speed for model quality? (1/2)\n",
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b>Note:</b> If you just want to get an idea of the process of training <nobr>Micro$\\mathbb{S}$plit</nobr> and you do not intend to get best-possible results, feel invited to crop down on the training data to be used further down. <i><b>Do not do this</b> if you intend to train a competitive model!!!</i>\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# If True, training and validation data will be reduced to only \n",
+        "# consisting of 2 and 1 frames, respectively.\n",
+        "reduce_data = True\n",
+        "\n",
+        "if reduce_data:\n",
+        "    print(\"Using REDUCED training and validation data for quick'n'dirty testing!\")\n",
+        "    train_dset.reduce_data(list(range(10)))\n",
+        "    val_dset.reduce_data([0])\n",
+        "else:\n",
+        "    print('Using the full set of training and validation data!')\n",
+        "print(f'(This are {train_dset.get_num_frames()} and {val_dset.get_num_frames()} frames, respectively.)') "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "train_dset._data.dtype"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Final step: create Dataloaders for network training"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "train_dloader = DataLoader(\n",
+        "    train_dset,\n",
+        "    batch_size=experiment_params[\"batch_size\"],\n",
+        "    num_workers=experiment_params[\"num_workers\"],\n",
+        "    shuffle=True,\n",
+        ")\n",
+        "val_dloader = DataLoader(\n",
+        "    val_dset,\n",
+        "    batch_size=experiment_params[\"batch_size\"],\n",
+        "    num_workers=experiment_params[\"num_workers\"],\n",
+        "    shuffle=False,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.2:** Prepare <nobr>Micro$\\mathbb{S}$plit</nobr> Training\n",
+        "Next, we create all the configs for the upcoming network training run. These lines are not very intuitive and if you don't intend to dive really deep into CAREamics and the internals of <nobr>Micro$\\mathbb{S}$plit</nobr>, you might just execute these cells and move on."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# making our data_stas known to the experiment we prepare\n",
+        "experiment_params[\"data_stats\"] = data_stats\n",
+        "\n",
+        "# setting up training losses and model config (using default parameters)\n",
+        "loss_config = get_loss_config(**experiment_params)\n",
+        "model_config = get_model_config(**experiment_params)\n",
+        "gaussian_lik_config, noise_model_config, nm_lik_config = get_likelihood_config(\n",
+        "    **experiment_params\n",
+        ")\n",
+        "training_config = get_training_config(**experiment_params)\n",
+        "\n",
+        "# setting up learning rate scheduler and optimizer (using default parameters)\n",
+        "lr_scheduler_config = get_lr_scheduler_config(**experiment_params)\n",
+        "optimizer_config = get_optimizer_config(**experiment_params)\n",
+        "\n",
+        "# finally, assemble the full set of experiment configurations...\n",
+        "experiment_config = create_algorithm_config(\n",
+        "    algorithm=experiment_params[\"algorithm\"],\n",
+        "    loss_config=loss_config,\n",
+        "    model_config=model_config,\n",
+        "    gaussian_lik_config=gaussian_lik_config,\n",
+        "    nm_config=noise_model_config,\n",
+        "    nm_lik_config=nm_lik_config,\n",
+        "    lr_scheduler_config=lr_scheduler_config,\n",
+        "    optimizer_config=optimizer_config,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Wanna trade speed for model quality? (2/2)\n",
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b>Note:</b> Similar to above, if you simply want to go over this notebook quickly and you don't care about training a competitive model, set <i>`reduce_training_epochs=True`</i> in the cell below. \n",
+        "\n",
+        "Note that if <i> reduce_training_epochs </i> is set to <i>False </i>, the default number of epochs is 400. However, early stopping will be invoked when the loss is no longer decreasing, so the actual number of epochs trained will most likely be less than 400.\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "reduce_training_epochs = True\n",
+        "\n",
+        "# if True, train for only 10 epochs (quick'n'dirty testing mode)\n",
+        "if reduce_training_epochs:\n",
+        "    training_config.num_epochs = 10\n",
+        "\n",
+        "print(f'Will train for {training_config.num_epochs} epochs!')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Initialize the <nobr>Micro$\\mathbb{S}$plit</nobr> model to be trained.."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "model = VAEModule(algorithm_config=experiment_config)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### *Load checkpoint (optional and for you to implement)*\n",
+        "\n",
+        "<div class=\"alert alert-block alert-success\">\n",
+        "<b>Note:</b> If you would like to continue a previous training run or finetune a compatible pre-trained model, here would be a good place. You will need to figure out how to implement this for your use-case, but to give you a head-start, we left three potentially useful lines of code below.\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# from microsplit_reproducibility.notebook_utils.HT_LIF24 import load_pretrained_model\n",
+        "# ckpt_path = load_checkpoint_path(f\"./pretrained_checkpoints/{EXPOSURE_DURATION}/\", best=True)\n",
+        "# load_pretrained_model(model, ckpt_path)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### If you're not using MPS as your accelerator, ingore next cell"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# If you encounter float \"Cannot convert a MPS Tensor to float64\" error, run this cell\n",
+        "from microsplit_reproducibility.utils.utils import cast_model_floats\n",
+        "cast_model_floats(model)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Show some training data for a final check!\n",
+        "***Tip:*** we show you a few samples of the prepared training data. In case you don't like what you see, execute the cell again and other randomly chosen patches will be shown!"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "plot_input_patches(dataset=train_dset, num_channels=len(TARGET_CHANNEL_IDX_LIST), num_samples=3, patch_size=128)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.3:** Train the prepared model!\n",
+        "***Note:*** if this takes too long, there were to places above where we gave you options to *(i)* reduce the amount of training data, and *(ii)* chose to train for fewer epochs. Revisit your choices if you want to!\n",
+        "\n",
+        "***Note:*** Depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> above.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# create a CAREamics 'Trainer'\n",
+        "trainer = Trainer(\n",
+        "    max_epochs=training_config.num_epochs,\n",
+        "    # NOTE: if you are on a mac swap the accelerator to \"mps\"\n",
+        "    accelerator=\"mps\",\n",
+        "    # accelerator=\"gpu\",\n",
+        "    enable_progress_bar=True,\n",
+        "    callbacks=get_callbacks(f\"./checkpoints/{EXPOSURE_DURATION}\"),\n",
+        "    precision=training_config.precision,\n",
+        "    gradient_clip_val=training_config.gradient_clip_val,\n",
+        "    gradient_clip_algorithm=training_config.gradient_clip_algorithm,\n",
+        ")\n",
+        "# start the training - yay!\n",
+        "trainer.fit(\n",
+        "    model=model,\n",
+        "    train_dataloaders=train_dloader,\n",
+        "    val_dataloaders=val_dloader,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Show training loss curves...\n",
+        "Below, we plot for each epoch of your training run the *(i)* training reconstruction loss, *(ii)* training KL divergence loss, *(iii)* validation reconstruction loss, and *(iv)* validation PSNR. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pandas import read_csv\n",
+        "from microsplit_reproducibility.notebook_utils.HT_LIF24 import find_recent_metrics, plot_metrics\n",
+        "df = read_csv(find_recent_metrics())\n",
+        "plot_metrics(df)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.4:** Predict and visualize results for validation data..."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "experiment_params['mmse_count'] = 10"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "scrolled": true
+      },
+      "outputs": [],
+      "source": [
+        "from microsplit_reproducibility.notebook_utils.HT_LIF24 import get_unnormalized_predictions, get_target, get_input\n",
+        "stitched_predictions, _, _ = get_unnormalized_predictions(model, val_dset, EXPOSURE_DURATION, TARGET_CHANNEL_IDX_LIST, \n",
+        "                                                    mmse_count = experiment_params['mmse_count'], num_workers=0, batch_size=32)\n",
+        "tar = get_target(val_dset)\n",
+        "inp = get_input(val_dset)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Overview: visualize predictions on validation data..."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from microsplit_reproducibility.notebook_utils.HT_LIF24 import full_frame_evaluation\n",
+        "frame_idx = 0\n",
+        "assert frame_idx < len(stitched_predictions), f\"Frame index {frame_idx} out of bounds\"\n",
+        "full_frame_evaluation(stitched_predictions[frame_idx], tar[frame_idx], inp[frame_idx])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Detailed view on some (foreground) locations...\n",
+        "Below, we show few random foreground locations and the corresponding <nobr>Micro$\\mathbb{S}$plit</nobr> predictions.\n",
+        "\n",
+        "As before, also here you can execute the cell multiple times and different randomly chosen locations will be plotted."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "from microsplit_reproducibility.utils.utils import clean_ax\n",
+        "from microsplit_reproducibility.notebook_utils.HT_LIF24 import pick_random_patches_with_content\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "img_sz = 128\n",
+        "rand_locations = pick_random_patches_with_content(tar, 128)\n",
+        "h_start = rand_locations[2,0] #np.random.randint(stitched_predictions.shape[1] - img_sz)\n",
+        "w_start = rand_locations[2,1] #np.random.randint(stitched_predictions.shape[2] - img_sz)\n",
+        "\n",
+        "ncols = 2*len(TARGET_CHANNEL_IDX_LIST) + 1\n",
+        "nrows = min(len(rand_locations), 5)\n",
+        "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 3, nrows * 3))\n",
+        "\n",
+        "for i, (h_start, w_start) in enumerate(rand_locations[:nrows]):\n",
+        "    ax[i,0].imshow(inp[0,h_start:h_start+img_sz, w_start:w_start+img_sz])\n",
+        "    for j in range(ncols//2):\n",
+        "        vmin = stitched_predictions[0,h_start:h_start+img_sz, w_start:w_start+img_sz,j].min()\n",
+        "        vmax = stitched_predictions[0,h_start:h_start+img_sz, w_start:w_start+img_sz,j].max()\n",
+        "        ax[i,2*j+1].imshow(tar[0,h_start:h_start+img_sz, w_start:w_start+img_sz,j], vmin=vmin, vmax=vmax)\n",
+        "        ax[i,2*j+2].imshow(stitched_predictions[0,h_start:h_start+img_sz, w_start:w_start+img_sz,j], vmin=vmin, vmax=vmax)\n",
+        "\n",
+        "ax[0,0].set_title('Primary Input')\n",
+        "for i in range(len(TARGET_CHANNEL_IDX_LIST)):\n",
+        "    ax[0,2*i+1].set_title(f'Target Channel {i+1}')\n",
+        "    ax[0,2*i+2].set_title(f'Predicted Channel {i+1}')\n",
+        "\n",
+        "# reduce the spacing between the subplots\n",
+        "plt.subplots_adjust(wspace=0.03, hspace=0.03)\n",
+        "clean_ax(ax)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## *Optional:* manual inspection of the predictions\n",
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b> Task:</b> Set <i>y_start</i>, <i>x_start</i>, and <i>crop_size</i> to inspect the predictions at a  location of your choice.\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "y_start = 600  #np.random.randint(stitched_predictions.shape[1] - crop_size)\n",
+        "x_start = 1150 #np.random.randint(stitched_predictions.shape[2] - crop_size)\n",
+        "crop_size = 128\n",
+        "\n",
+        "ncols = len(TARGET_CHANNEL_IDX_LIST) + 1\n",
+        "nrows = 2\n",
+        "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 5, nrows * 5))\n",
+        "ax[0,0].imshow(inp[0,y_start:y_start+crop_size, x_start:x_start+crop_size])\n",
+        "for i in range(ncols -1):\n",
+        "    vmin = stitched_predictions[0,y_start:y_start+crop_size, x_start:x_start+crop_size,i].min()\n",
+        "    vmax = stitched_predictions[0,y_start:y_start+crop_size, x_start:x_start+crop_size,i].max()\n",
+        "    ax[0,i+1].imshow(tar[0,y_start:y_start+crop_size, x_start:x_start+crop_size,i], vmin=vmin, vmax=vmax)\n",
+        "    ax[0,i+1].set_title(f\"Channel {i+1}\")\n",
+        "    ax[1,i+1].imshow(stitched_predictions[0,y_start:y_start+crop_size, x_start:x_start+crop_size,i], vmin=vmin, vmax=vmax)\n",
+        "\n",
+        "# disable the axis for ax[1,0]\n",
+        "ax[0,0].set_title(\"Input\")\n",
+        "\n",
+        "print('Here the crop you selected:')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# ***Optional Step 1.4:*** Posterior Sampling\n",
+        "For a given input patch, <nobr>Micro$\\mathbb{S}$plit</nobr> can generate multiple outputs. This is possible because <nobr>Micro$\\mathbb{S}$plit</nobr> is learning a full posterior of possible solutions, which is a quite powerful feature!\n",
+        "\n",
+        "As we elaborate in the <nobr>Micro$\\mathbb{S}$plit</nobr> paper and also later in the calibration notebook `03_calibration.ipynb`, this allows users to visually judge and even quantify the (data) uncertainty in the predictions their trained model makes.\n",
+        "\n",
+        "Below, we show two posterior samples and how much they differ for a few random foreground locations. Re-run the cell to see different randomly choosen locations and corresponding posterior samples."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from microsplit_reproducibility.notebook_utils.HT_LIF24 import show_sampling\n",
+        "imgsz = 3\n",
+        "ncols = 6\n",
+        "examplecount = 3\n",
+        "_,ax = plt.subplots(figsize=(imgsz*ncols, imgsz*2*examplecount), ncols=ncols, nrows=2*examplecount)\n",
+        "\n",
+        "show_sampling(val_dset, model, ax=ax[:2])\n",
+        "show_sampling(val_dset, model, ax=ax[2:4])\n",
+        "show_sampling(val_dset, model, ax=ax[4:6])\n",
+        "plt.tight_layout()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### You are done here! 👍 Congratulations! 🎉"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.14"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Introduction - what does this notebook do?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> Despite network training arguably being the most important step, the execution of this notebook is optional. If you do not run this notebook, in Step 2 (prediction) we offer you to use pretrained model checkpoints. Like in any respected cooking show: \"we have already prepared someting before the show\"... 😉\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Below, we will train a <nobr>Micro$\\mathbb{S}$plit</nobr> network for unmixing two superimposed channels from our HT-LIF24 dataset. \n",
-    "\n",
-    "This dataset contains four labeled structures, and soon you will be asked to choose which of these two you want to learn to unmix: \n",
-    "1. Cell Nucleui,\n",
-    "1. Microtubules,\n",
-    "1. Nuclear Membrane, and\n",
-    "1. Centromeres/Kinetocores.\n",
-    "\n",
-    "Additionally to four total structures, this dataset also offers acquisitions taken with different exposure times, hence, the data is available at various SNR, i.e. [signal-to-noise ratios](https://en.wikipedia.org/wiki/Signal-to-noise_ratio#:~:text=Signal%2Dto%2Dnoise%20ratio%20(,power%2C%20often%20expressed%20in%20decibels.). Shorter exposure times lead to a collection of fewer photos, which leads to more noise and therefore a lower SNR.\n",
-    "\n",
-    "The lower the SNR of the data you will choose to train <nobr>Micro$\\mathbb{S}$plit</nobr> with, the more important will the unsupervised denoising feature of <nobr>Micro$\\mathbb{S}$plit</nobr> become.\n",
-    "\n",
-    "But enough introduction, let's begin!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Background: what is <nobr>Micro$\\mathbb{S}$plit</nobr> training all about?\n",
-    "Training is done in a supervised way. For every input patch, we have the two corresponding target patches using which we train our MicroSplit. \n",
-    "Besides the primary input patch, we also feed LC inputs to MicroSplit. We introduced LC inputs in [μSplit: efficient image decomposition for microscopy data](https://openaccess.thecvf.com/content/ICCV2023/papers/Ashesh_uSplit_Image_Decomposition_for_Fluorescence_Microscopy_ICCV_2023_paper.pdf), which enabled the network to understand the global spatial context around the input patch.\n",
-    "\n",
-    "To enable unsupervised denoising, we integrated the KL loss formulation and Noise models from our previous work [denoiSplit: a method for joint microscopy image splitting and unsupervised denoising](https://eccv.ecva.net/virtual/2024/poster/2538). \n",
-    "\n",
-    "The loss function for MicroSplit is a weighted average of denoiSplit loss and μSplit loss. For both denoiSplit and μSplit, their loss expression have two terms: KL divergence loss and likelihood loss. For more details, please refer to the respective papers."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Let's do it, let's train a <nobr>Micro$\\mathbb{S}$plit</nobr> Model!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**You are new to Jupyter notebooks?** Don't worry, if you take the time to read all our explanations, we will guide you through them and you will understand a lot. Still, you will likely end up less frustrated, if you do not even start with the ambition to interpret the purpose of every line of code.\n",
-    "Let's start with a nice example, the imports to enable the remainder of this notebook. Ignore it (unless you know what you are doing) and just click **⇧*Shift* + ⏎*Enter*** to execute this (and all other) code cells. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# importing all the things we need further down\n",
-    "import platform\n",
-    "import pooch\n",
-    "from pathlib import Path\n",
-    "from pytorch_lightning import Trainer\n",
-    "from torch.utils.data import DataLoader\n",
-    "from careamics.lightning import VAEModule\n",
-    "\n",
-    "from microsplit_reproducibility.configs.factory import (\n",
-    "    create_algorithm_config,\n",
-    "    get_likelihood_config,\n",
-    "    get_loss_config,\n",
-    "    get_model_config,\n",
-    "    get_optimizer_config,\n",
-    "    get_training_config,\n",
-    "    get_lr_scheduler_config,\n",
-    ")\n",
-    "from microsplit_reproducibility.utils.callbacks import get_callbacks\n",
-    "from microsplit_reproducibility.utils.io import load_checkpoint, load_checkpoint_path\n",
-    "from microsplit_reproducibility.datasets import create_train_val_datasets\n",
-    "from microsplit_reproducibility.utils.utils import (\n",
-    "    plot_training_metrics,\n",
-    "    plot_input_patches,\n",
-    "    plot_training_outputs,\n",
-    ")\n",
-    "\n",
-    "# Dataset specific imports...\n",
-    "from microsplit_reproducibility.configs.parameters.HT_LIF24 import get_microsplit_parameters\n",
-    "from microsplit_reproducibility.configs.data.HT_LIF24 import get_data_configs\n",
-    "from microsplit_reproducibility.datasets.HT_LIF24 import get_train_val_data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.1:** Data Preparation\n",
-    "\n",
-    "Without any special modifications, **the following few steps will first choose which subset of the *HT_LIF24* dataset to use and then train a <nobr>Micro$\\mathbb{S}$plit</nobr> Model on this data**.\n",
-    "\n",
-    "The reason to pick a subset of the *HT_LIF24* dataset is, that we recorded this data with multiple possible learning tasks in mind. Check the <nobr>Micro$\\mathbb{S}$plit</nobr> paper for all the details.\n",
-    "\n",
-    "This logic you find below will likely also apply to your needs when training on your own data (in case this is what you are after). Still, don't shy away from deviating from the code you find below..."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Select the 2, 3 or 4 channels you want train on, and the exposure time (SNR) of these channel acquisitions you want to use...\n",
-    "To make things more human readable, we use the utility function."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The next line is likely a bit confusing at first.\n",
-    "\n",
-    "Since the channel unmixing capabilities of <nobr>Micro$\\mathbb{S}$plit</nobr> are trained in a supervised way, we must later feed *(i)* input images that contain certain number of selected structures, and *(ii)* corresponding number of separate channels that show these structures separately.\n",
-    "\n",
-    "The following code cell will help you to select the channels and exposure time you want to train on.\n",
-    "Exposure duration is a parameter of this particular experience and is defined in seconds.\n",
-    "\n",
-    "    VeryLow = \"2ms\"\n",
-    "    Low = \"3ms\"\n",
-    "    Medium = \"5ms\"\n",
-    "    High = \"20ms\"\n",
-    "    VeryHigh = \"500ms\"\n",
-    "\n",
-    "Names of channels follow the following convention:\n",
-    "\n",
-    "    Nucleus = 0\n",
-    "    MicroTubules = 1\n",
-    "    NuclearMembrane = 2\n",
-    "    Centromere = 3\n",
-    "    Input = 11"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from microsplit_reproducibility.notebook_utils.HT_LIF24 import ExposureDuration, define_experiment_config\n",
-    "\n",
-    "CHANNEL_IDX_LIST, TARGET_CHANNEL_IDX_LIST, EXPOSURE_DURATION = define_experiment_config(\n",
-    "    num_channels=2, exposure=ExposureDuration.Medium)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Download the data you need (given your choices from above)\n",
-    "Depending on your internet connection, this will take a while...\n",
-    "\n",
-    "Note that appropriate noise models will only be downloaded if they were not created by executing the notebook `00_noisemodels.ipynb`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "DATA = pooch.create(\n",
-    "    path=\"./data/\",\n",
-    "    base_url=\"https://download.fht.org/jug/msplit/ht_lif24/data/\",\n",
-    "    registry={f\"ht_lif24_{EXPOSURE_DURATION}.zip\": None},\n",
-    ")\n",
-    "\n",
-    "NOISE_MODELS = pooch.create(\n",
-    "    path=f\"./noise_models/{EXPOSURE_DURATION}/\",\n",
-    "    base_url=f\"https://download.fht.org/jug/msplit/ht_lif24/noise_models/{EXPOSURE_DURATION}/\",\n",
-    "    registry={\n",
-    "        f\"noise_model_Ch{channel_idx}.npz\": None\n",
-    "        for channel_idx in TARGET_CHANNEL_IDX_LIST\n",
-    "    },\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that the following notebook will download all you need. In case you see no messages announcing any downloads, you already have this data in the notebook folder."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for fname in NOISE_MODELS.registry:\n",
-    "    NOISE_MODELS.fetch(fname, progressbar=True)\n",
-    "print('---------')\n",
-    "for fname in DATA.registry:\n",
-    "    DATA.fetch(fname, processor=pooch.Unzip(), progressbar=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Next, we load the image data to be processed\n",
-    "\n",
-    "Note that depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> below.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# setting up train, validation, and test data configs\n",
-    "train_data_config, val_data_config, test_data_config = get_data_configs(\n",
-    "    dset_type=EXPOSURE_DURATION, channel_idx_list=CHANNEL_IDX_LIST,\n",
-    ")\n",
-    "# setting up MicroSplit parametrization\n",
-    "experiment_params = get_microsplit_parameters(\n",
-    "    dset_type=EXPOSURE_DURATION, nm_path=NOISE_MODELS.path, channel_idx_list=CHANNEL_IDX_LIST, batch_size=32\n",
-    ")\n",
-    "\n",
-    "# start the download of required files\n",
-    "train_dset, val_dset, _, data_stats = create_train_val_datasets(\n",
-    "    datapath=DATA.path / f\"ht_lif24_{EXPOSURE_DURATION}.zip.unzip/{EXPOSURE_DURATION}\",\n",
-    "    train_config=train_data_config,\n",
-    "    val_config=val_data_config,\n",
-    "    test_config=val_data_config,\n",
-    "    load_data_func=get_train_val_data,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Configure `num_workers`\n",
-    "In Windows and MacOS, setting `num_workers > 0` for dataloaders would cause out-of-memory issue and might crash the system."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_num_workers():\n",
-    "    \"\"\"Utility function to set num_workers based on OS.\"\"\"\n",
-    "    if platform.system() == \"Windows\" or platform.system() == \"Darwin\":\n",
-    "        return 0\n",
-    "    else:\n",
-    "        return 3  # or any other number suitable for your system\n",
-    "\n",
-    "experiment_params[\"num_workers\"] = get_num_workers()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "***Optional:*** inspect data configurations and <nobr>Micro$\\mathbb{S}$plit</nobr> config"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "do_show_configs = True\n",
-    "\n",
-    "if do_show_configs:\n",
-    "    print('FYI: train_data_config')\n",
-    "    print('----------------------')\n",
-    "    for cfg in train_data_config:\n",
-    "        print(cfg)\n",
-    "\n",
-    "    print('\\nFYI: experiment_params')\n",
-    "    print('----------------------')\n",
-    "    print(experiment_params)\n",
-    "else:\n",
-    "    print('You opted out of having all params printed... swiftly moving on... ;)')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Wanna trade speed for model quality? (1/2)\n",
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> If you just want to get an idea of the process of training <nobr>Micro$\\mathbb{S}$plit</nobr> and you do not intend to get best-possible results, feel invited to crop down on the training data to be used further down. <i><b>Do not do this</b> if you intend to train a competitive model!!!</i>\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# If True, training and validation data will be reduced to only \n",
-    "# consisting of 2 and 1 frames, respectively.\n",
-    "reduce_data = True\n",
-    "\n",
-    "if reduce_data:\n",
-    "    print(\"Using REDUCED training and validation data for quick'n'dirty testing!\")\n",
-    "    train_dset.reduce_data(list(range(10)))\n",
-    "    val_dset.reduce_data([0])\n",
-    "else:\n",
-    "    print('Using the full set of training and validation data!')\n",
-    "print(f'(This are {train_dset.get_num_frames()} and {val_dset.get_num_frames()} frames, respectively.)') "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "train_dset._data.dtype"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Final step: create Dataloaders for network training"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "train_dloader = DataLoader(\n",
-    "    train_dset,\n",
-    "    batch_size=experiment_params[\"batch_size\"],\n",
-    "    num_workers=experiment_params[\"num_workers\"],\n",
-    "    shuffle=True,\n",
-    ")\n",
-    "val_dloader = DataLoader(\n",
-    "    val_dset,\n",
-    "    batch_size=experiment_params[\"batch_size\"],\n",
-    "    num_workers=experiment_params[\"num_workers\"],\n",
-    "    shuffle=False,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.2:** Prepare <nobr>Micro$\\mathbb{S}$plit</nobr> Training\n",
-    "Next, we create all the configs for the upcoming network training run. These lines are not very intuitive and if you don't intend to dive really deep into CAREamics and the internals of <nobr>Micro$\\mathbb{S}$plit</nobr>, you might just execute these cells and move on."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# making our data_stas known to the experiment we prepare\n",
-    "experiment_params[\"data_stats\"] = data_stats\n",
-    "\n",
-    "# setting up training losses and model config (using default parameters)\n",
-    "loss_config = get_loss_config(**experiment_params)\n",
-    "model_config = get_model_config(**experiment_params)\n",
-    "gaussian_lik_config, noise_model_config, nm_lik_config = get_likelihood_config(\n",
-    "    **experiment_params\n",
-    ")\n",
-    "training_config = get_training_config(**experiment_params)\n",
-    "\n",
-    "# setting up learning rate scheduler and optimizer (using default parameters)\n",
-    "lr_scheduler_config = get_lr_scheduler_config(**experiment_params)\n",
-    "optimizer_config = get_optimizer_config(**experiment_params)\n",
-    "\n",
-    "# finally, assemble the full set of experiment configurations...\n",
-    "experiment_config = create_algorithm_config(\n",
-    "    algorithm=experiment_params[\"algorithm\"],\n",
-    "    loss_config=loss_config,\n",
-    "    model_config=model_config,\n",
-    "    gaussian_lik_config=gaussian_lik_config,\n",
-    "    nm_config=noise_model_config,\n",
-    "    nm_lik_config=nm_lik_config,\n",
-    "    lr_scheduler_config=lr_scheduler_config,\n",
-    "    optimizer_config=optimizer_config,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Wanna trade speed for model quality? (2/2)\n",
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> Similar to above, if you simply want to go over this notebook quickly and you don't care about training a competitive model, set <i>`reduce_training_epochs=True`</i> in the cell below. \n",
-    "\n",
-    "Note that if <i> reduce_training_epochs </i> is set to <i>False </i>, the default number of epochs is 400. However, early stopping will be invoked when the loss is no longer decreasing, so the actual number of epochs trained will most likely be less than 400.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reduce_training_epochs = True\n",
-    "\n",
-    "# if True, train for only 10 epochs (quick'n'dirty testing mode)\n",
-    "if reduce_training_epochs:\n",
-    "    training_config.num_epochs = 10\n",
-    "\n",
-    "print(f'Will train for {training_config.num_epochs} epochs!')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Initialize the <nobr>Micro$\\mathbb{S}$plit</nobr> model to be trained.."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model = VAEModule(algorithm_config=experiment_config)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### *Load checkpoint (optional and for you to implement)*\n",
-    "\n",
-    "<div class=\"alert alert-block alert-success\">\n",
-    "<b>Note:</b> If you would like to continue a previous training run or finetune a compatible pre-trained model, here would be a good place. You will need to figure out how to implement this for your use-case, but to give you a head-start, we left three potentially useful lines of code below.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# from microsplit_reproducibility.notebook_utils.HT_LIF24 import load_pretrained_model\n",
-    "# ckpt_path = load_checkpoint_path(f\"./pretrained_checkpoints/{EXPOSURE_DURATION}/\", best=True)\n",
-    "# load_pretrained_model(model, ckpt_path)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Show some training data for a final check!\n",
-    "***Tip:*** we show you a few samples of the prepared training data. In case you don't like what you see, execute the cell again and other randomly chosen patches will be shown!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_input_patches(dataset=train_dset, num_channels=len(TARGET_CHANNEL_IDX_LIST), num_samples=3, patch_size=128)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.3:** Train the prepared model!\n",
-    "***Note:*** if this takes too long, there were to places above where we gave you options to *(i)* reduce the amount of training data, and *(ii)* chose to train for fewer epochs. Revisit your choices if you want to!\n",
-    "\n",
-    "***Note:*** Depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> above.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# create a CAREamics 'Trainer'\n",
-    "trainer = Trainer(\n",
-    "    max_epochs=training_config.num_epochs,\n",
-    "    # NOTE: if you are on a mac swap the accelerator to \"mps\"\n",
-    "    accelerator=\"mps\",\n",
-    "    # accelerator=\"gpu\",\n",
-    "    enable_progress_bar=True,\n",
-    "    callbacks=get_callbacks(f\"./checkpoints/{EXPOSURE_DURATION}\"),\n",
-    "    precision=training_config.precision,\n",
-    "    gradient_clip_val=training_config.gradient_clip_val,\n",
-    "    gradient_clip_algorithm=training_config.gradient_clip_algorithm,\n",
-    ")\n",
-    "# start the training - yay!\n",
-    "trainer.fit(\n",
-    "    model=model,\n",
-    "    train_dataloaders=train_dloader,\n",
-    "    val_dataloaders=val_dloader,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Show training loss curves...\n",
-    "Below, we plot for each epoch of your training run the *(i)* training reconstruction loss, *(ii)* training KL divergence loss, *(iii)* validation reconstruction loss, and *(iv)* validation PSNR. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pandas import read_csv\n",
-    "from microsplit_reproducibility.notebook_utils.HT_LIF24 import find_recent_metrics, plot_metrics\n",
-    "df = read_csv(find_recent_metrics())\n",
-    "plot_metrics(df)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.4:** Predict and visualize results for validation data..."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "experiment_params['mmse_count'] = 10"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "from microsplit_reproducibility.notebook_utils.HT_LIF24 import get_unnormalized_predictions, get_target, get_input\n",
-    "stitched_predictions, _, _ = get_unnormalized_predictions(model, val_dset, EXPOSURE_DURATION, TARGET_CHANNEL_IDX_LIST, \n",
-    "                                                    mmse_count = experiment_params['mmse_count'], num_workers=0, batch_size=32)\n",
-    "tar = get_target(val_dset)\n",
-    "inp = get_input(val_dset)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Overview: visualize predictions on validation data..."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from microsplit_reproducibility.notebook_utils.HT_LIF24 import full_frame_evaluation\n",
-    "frame_idx = 0\n",
-    "assert frame_idx < len(stitched_predictions), f\"Frame index {frame_idx} out of bounds\"\n",
-    "full_frame_evaluation(stitched_predictions[frame_idx], tar[frame_idx], inp[frame_idx])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Detailed view on some (foreground) locations...\n",
-    "Below, we show few random foreground locations and the corresponding <nobr>Micro$\\mathbb{S}$plit</nobr> predictions.\n",
-    "\n",
-    "As before, also here you can execute the cell multiple times and different randomly chosen locations will be plotted."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "from microsplit_reproducibility.utils.utils import clean_ax\n",
-    "from microsplit_reproducibility.notebook_utils.HT_LIF24 import pick_random_patches_with_content\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "img_sz = 128\n",
-    "rand_locations = pick_random_patches_with_content(tar, 128)\n",
-    "h_start = rand_locations[2,0] #np.random.randint(stitched_predictions.shape[1] - img_sz)\n",
-    "w_start = rand_locations[2,1] #np.random.randint(stitched_predictions.shape[2] - img_sz)\n",
-    "\n",
-    "ncols = 2*len(TARGET_CHANNEL_IDX_LIST) + 1\n",
-    "nrows = min(len(rand_locations), 5)\n",
-    "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 3, nrows * 3))\n",
-    "\n",
-    "for i, (h_start, w_start) in enumerate(rand_locations[:nrows]):\n",
-    "    ax[i,0].imshow(inp[0,h_start:h_start+img_sz, w_start:w_start+img_sz])\n",
-    "    for j in range(ncols//2):\n",
-    "        vmin = stitched_predictions[0,h_start:h_start+img_sz, w_start:w_start+img_sz,j].min()\n",
-    "        vmax = stitched_predictions[0,h_start:h_start+img_sz, w_start:w_start+img_sz,j].max()\n",
-    "        ax[i,2*j+1].imshow(tar[0,h_start:h_start+img_sz, w_start:w_start+img_sz,j], vmin=vmin, vmax=vmax)\n",
-    "        ax[i,2*j+2].imshow(stitched_predictions[0,h_start:h_start+img_sz, w_start:w_start+img_sz,j], vmin=vmin, vmax=vmax)\n",
-    "\n",
-    "ax[0,0].set_title('Primary Input')\n",
-    "for i in range(len(TARGET_CHANNEL_IDX_LIST)):\n",
-    "    ax[0,2*i+1].set_title(f'Target Channel {i+1}')\n",
-    "    ax[0,2*i+2].set_title(f'Predicted Channel {i+1}')\n",
-    "\n",
-    "# reduce the spacing between the subplots\n",
-    "plt.subplots_adjust(wspace=0.03, hspace=0.03)\n",
-    "clean_ax(ax)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## *Optional:* manual inspection of the predictions\n",
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b> Task:</b> Set <i>y_start</i>, <i>x_start</i>, and <i>crop_size</i> to inspect the predictions at a  location of your choice.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "y_start = 600  #np.random.randint(stitched_predictions.shape[1] - crop_size)\n",
-    "x_start = 1150 #np.random.randint(stitched_predictions.shape[2] - crop_size)\n",
-    "crop_size = 128\n",
-    "\n",
-    "ncols = len(TARGET_CHANNEL_IDX_LIST) + 1\n",
-    "nrows = 2\n",
-    "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 5, nrows * 5))\n",
-    "ax[0,0].imshow(inp[0,y_start:y_start+crop_size, x_start:x_start+crop_size])\n",
-    "for i in range(ncols -1):\n",
-    "    vmin = stitched_predictions[0,y_start:y_start+crop_size, x_start:x_start+crop_size,i].min()\n",
-    "    vmax = stitched_predictions[0,y_start:y_start+crop_size, x_start:x_start+crop_size,i].max()\n",
-    "    ax[0,i+1].imshow(tar[0,y_start:y_start+crop_size, x_start:x_start+crop_size,i], vmin=vmin, vmax=vmax)\n",
-    "    ax[0,i+1].set_title(f\"Channel {i+1}\")\n",
-    "    ax[1,i+1].imshow(stitched_predictions[0,y_start:y_start+crop_size, x_start:x_start+crop_size,i], vmin=vmin, vmax=vmax)\n",
-    "\n",
-    "# disable the axis for ax[1,0]\n",
-    "ax[0,0].set_title(\"Input\")\n",
-    "\n",
-    "print('Here the crop you selected:')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# ***Optional Step 1.4:*** Posterior Sampling\n",
-    "For a given input patch, <nobr>Micro$\\mathbb{S}$plit</nobr> can generate multiple outputs. This is possible because <nobr>Micro$\\mathbb{S}$plit</nobr> is learning a full posterior of possible solutions, which is a quite powerful feature!\n",
-    "\n",
-    "As we elaborate in the <nobr>Micro$\\mathbb{S}$plit</nobr> paper and also later in the calibration notebook `03_calibration.ipynb`, this allows users to visually judge and even quantify the (data) uncertainty in the predictions their trained model makes.\n",
-    "\n",
-    "Below, we show two posterior samples and how much they differ for a few random foreground locations. Re-run the cell to see different randomly choosen locations and corresponding posterior samples."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from microsplit_reproducibility.notebook_utils.HT_LIF24 import show_sampling\n",
-    "imgsz = 3\n",
-    "ncols = 6\n",
-    "examplecount = 3\n",
-    "_,ax = plt.subplots(figsize=(imgsz*ncols, imgsz*2*examplecount), ncols=ncols, nrows=2*examplecount)\n",
-    "\n",
-    "show_sampling(val_dset, model, ax=ax[:2])\n",
-    "show_sampling(val_dset, model, ax=ax[2:4])\n",
-    "show_sampling(val_dset, model, ax=ax[4:6])\n",
-    "plt.tight_layout()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### You are done here! 👍 Congratulations! 🎉"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "careamics",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.14"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 4
 }

--- a/examples/2D/custom_dataset/01_train.ipynb
+++ b/examples/2D/custom_dataset/01_train.ipynb
@@ -1,772 +1,790 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1:** Training a <nobr>Micro$\\mathbb{S}$plit</nobr> Model"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1:** Training a <nobr>Micro$\\mathbb{S}$plit</nobr> Model"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Introduction - what does this notebook do?"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Below, we will train a <nobr>Micro$\\mathbb{S}$plit</nobr> network for unmixing two superimposed channels for a custom dataset you provide. "
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b>Important:</b> How to organize your data for training a <nobr>Micro$\\mathbb{S}$plit</nobr> model\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b>Note:</b> We provide example data for this set of notebooks also, but the intention is to let a user use their own data.\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Below, we will train a <nobr>Micro$\\mathbb{S}$plit</nobr> network for unmixing two or more superimposed channels for a custom 2D dataset you provide. \n",
+        "\n",
+        "You should organize you dataset as follows:\n",
+        "- Create a `data` directory\n",
+        "- Create subdirectories `channel_1`, `channel_2`, etc, containing the channels you would like to unmix\n",
+        "- Make sure that the images have the same spatial size and each image has only 1 channel\n",
+        "\n",
+        "Your data directory should look like this:\n",
+        "```\n",
+        "you_data_path/\n",
+        "└── data\n",
+        "    ├── channel_1\n",
+        "    │   ├── image1.tiff\n",
+        "    │   ├── image2.tiff\n",
+        "    │   └── image3.tiff\n",
+        "    └── channel_2\n",
+        "    │   ├── image1.tiff\n",
+        "    │   ├── image2.tiff\n",
+        "    │   └── image3.tiff\n",
+        "    └── channel_n\n",
+        "    │   ├── image1.tiff\n",
+        "    │   ├── image2.tiff\n",
+        "    │   └── image3.tiff\n",
+        "```\n",
+        "\n",
+        "The mixed image used for splitting will be obtained artificially by a convex combination of the target channels.\n",
+        "\n",
+        "Let's begin!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Background: what is <nobr>Micro$\\mathbb{S}$plit</nobr> training all about?\n",
+        "Training is done in a supervised way. For every input patch, we have the two corresponding target patches using which we train our MicroSplit. \n",
+        "Besides the primary input patch, we also feed LC inputs to MicroSplit. We introduced LC inputs in [μSplit: efficient image decomposition for microscopy data](https://openaccess.thecvf.com/content/ICCV2023/papers/Ashesh_uSplit_Image_Decomposition_for_Fluorescence_Microscopy_ICCV_2023_paper.pdf), which enabled the network to understand the global spatial context around the input patch.\n",
+        "\n",
+        "To enable unsupervised denoising, we integrated the KL loss formulation and Noise models from our previous work [denoiSplit: a method for joint microscopy image splitting and unsupervised denoising](https://eccv.ecva.net/virtual/2024/poster/2538). \n",
+        "\n",
+        "The loss function for MicroSplit is a weighted average of denoiSplit loss and μSplit loss. For both denoiSplit and μSplit, their loss expression have two terms: KL divergence loss and likelihood loss. For more details, please refer to the respective papers."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Let's do it, let's train a <nobr>Micro$\\mathbb{S}$plit</nobr> Model!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**You are new to Jupyter notebooks?** Don't worry, if you take the time to read all our explanations, we will guide you through them and you will understand a lot. Still, you will likely end up less frustrated, if you do not even start with the ambition to interpret the purpose of every line of code.\n",
+        "Let's start with a nice example, the imports to enable the remainder of this notebook. Ignore it (unless you know what you are doing) and just click **⇧*Shift* + ⏎*Enter*** to execute this (and all other) code cells. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# importing all the things we need further down\n",
+        "import platform\n",
+        "from pathlib import Path\n",
+        "\n",
+        "import pooch\n",
+        "import matplotlib.pyplot as plt\n",
+        "from careamics.lightning import VAEModule\n",
+        "from pytorch_lightning import Trainer\n",
+        "from torch.utils.data import DataLoader\n",
+        "\n",
+        "from microsplit_reproducibility.configs.factory import (\n",
+        "    create_algorithm_config,\n",
+        "    get_likelihood_config,\n",
+        "    get_loss_config,\n",
+        "    get_model_config,\n",
+        "    get_optimizer_config,\n",
+        "    get_training_config,\n",
+        "    get_lr_scheduler_config,\n",
+        ")\n",
+        "from microsplit_reproducibility.utils.callbacks import get_callbacks\n",
+        "from microsplit_reproducibility.utils.io import load_checkpoint_path\n",
+        "from microsplit_reproducibility.datasets import create_train_val_datasets\n",
+        "from microsplit_reproducibility.utils.utils import plot_input_patches\n",
+        "\n",
+        "# Dataset specific imports...\n",
+        "from microsplit_reproducibility.configs.parameters.custom_dataset_2D import (\n",
+        "    get_microsplit_parameters\n",
+        ")\n",
+        "from microsplit_reproducibility.configs.data.custom_dataset_2D import get_data_configs\n",
+        "from microsplit_reproducibility.datasets.custom_dataset_2D import get_train_val_data"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.1:** Data Preparation"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Since the channel unmixing capabilities of <nobr>Micro$\\mathbb{S}$plit</nobr> are trained in a supervised way, we must later feed *(i)* input images that contain both selected structures, and *(ii)* two seperate channels that show these two structures separately. As previosuly mentioned, the mixed input image is obtained synthetically by overlapping the other two channels."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Load example data"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "DATA = pooch.create(\n",
+        "    path=f\"./data/\",\n",
+        "    base_url=f\"https://download.fht.org/jug/msplit/ht_lif24/data_tiff/\",\n",
+        "    registry={f\"ht_lif24_5ms_reduced.zip\": None},\n",
+        ")\n",
+        "for fname in DATA.registry:\n",
+        "    DATA.fetch(fname, processor=pooch.Unzip(), progressbar=True)\n",
+        "\n",
+        "DATA_PATH = DATA.abspath / (DATA.registry_files[0] + \".unzip/5ms/data/\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### OR set the path to your own data\n",
+        "Important: the path should end with `data/`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# DATA_PATH = Path(\"/my/path/data\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Setup the path to the noise models\n",
+        "This is the path to the noise models that you trained in the notebook **00_noisemodels.ipynb**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "NM_PATH = Path(\"./noise_models/\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Next, we load the image data to be processed\n",
+        "\n",
+        "***Note*** that depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> below.\n",
+        "\n",
+        "Number of epochs is set to 10, which usually allows to see decent results. However, for getting optimal performance you can increase it to 50.\n",
+        "\n",
+        "You also need to change the `num_channels` and `target_channels` parameters respectively for the `get_data_configs()` and the `get_microsplit_parameters` functions. These parameters have a similar meaning, i.e., they control the number of channels in the input data depending on how many channels you want to split.\n",
+        "\n",
+        "Finally, ensure that the `image_size` parameter (i.e., the patch size in (`Z`, `Y`, `X`) you want to use to train the model) is properly set given the size of your data and of you GPU."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "NUM_CHANNELS = 2\n",
+        "\"\"\"The number of channels considered for the splitting task.\"\"\"\n",
+        "BATCH_SIZE = 32\n",
+        "\"\"\"The batch size for training.\"\"\"\n",
+        "PATCH_SIZE = (64, 64)\n",
+        "\"\"\"The size of the patches fed to the network for training in (Y, X).\"\"\"\n",
+        "EPOCHS = 10\n",
+        "\"\"\"The number of epochs to train the network.\"\"\"\n",
+        "\n",
+        "assert len(PATCH_SIZE) == 2, \"PATCH_SIZE must be a tuple of length 2 (Y, X) since we are using 2D data.\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# setting up train, validation, and test data configs\n",
+        "train_data_config, val_data_config, test_data_config = get_data_configs(\n",
+        "    image_size=PATCH_SIZE,\n",
+        "    num_channels=NUM_CHANNELS\n",
+        ")\n",
+        "\n",
+        "# setting up MicroSplit parametrization\n",
+        "experiment_params = get_microsplit_parameters(\n",
+        "    algorithm=\"denoisplit\",\n",
+        "    img_size=PATCH_SIZE,\n",
+        "    batch_size=BATCH_SIZE,\n",
+        "    num_epochs=EPOCHS,\n",
+        "    multiscale_count=3,\n",
+        "    noise_model_path=NM_PATH,\n",
+        "    target_channels=NUM_CHANNELS,\n",
+        ")\n",
+        "\n",
+        "# create the dataset\n",
+        "train_dset, val_dset, _, data_stats = create_train_val_datasets(\n",
+        "    datapath=DATA_PATH,\n",
+        "    train_config=train_data_config,\n",
+        "    val_config=val_data_config,\n",
+        "    test_config=val_data_config,\n",
+        "    load_data_func=get_train_val_data,\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Configure `num_workers`\n",
+        "In Windows and MacOS, setting `num_workers > 0` for dataloaders would cause out-of-memory issue and might crash the system."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "def get_num_workers():\n",
+        "    \"\"\"Utility function to set num_workers based on OS.\"\"\"\n",
+        "    if platform.system() == \"Windows\" or platform.system() == \"Darwin\":\n",
+        "        return 0\n",
+        "    else:\n",
+        "        return 3  # or any other number suitable for your system\n",
+        "\n",
+        "experiment_params[\"num_workers\"] = get_num_workers()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "***Optional:*** inspect data configurations and <nobr>Micro$\\mathbb{S}$plit</nobr> config"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "do_show_configs = True\n",
+        "\n",
+        "if do_show_configs:\n",
+        "    print(\"FYI: train_data_config\")\n",
+        "    print(\"----------------------\")\n",
+        "    for cfg in train_data_config:\n",
+        "        print(cfg)\n",
+        "\n",
+        "    print(\"\\nFYI: experiment_params\")\n",
+        "    print(\"----------------------\")\n",
+        "    print(experiment_params)\n",
+        "else:\n",
+        "    print(\"You opted out of having all params printed... swiftly moving on... ;)\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Final step: create Dataloaders for network training"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "train_dloader = DataLoader(\n",
+        "    train_dset,\n",
+        "    batch_size=experiment_params[\"batch_size\"],\n",
+        "    num_workers=experiment_params[\"num_workers\"],\n",
+        "    shuffle=True,\n",
+        ")\n",
+        "val_dloader = DataLoader(\n",
+        "    val_dset,\n",
+        "    batch_size=experiment_params[\"batch_size\"],\n",
+        "    num_workers=experiment_params[\"num_workers\"],\n",
+        "    shuffle=False,\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.2:** Prepare <nobr>Micro$\\mathbb{S}$plit</nobr> Training\n",
+        "Next, we create all the configs for the upcoming network training run. These lines are not very intuitive and if you don't intend to dive really deep into CAREamics and the internals of <nobr>Micro$\\mathbb{S}$plit</nobr>, you might just execute these cells and move on."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# making our data_stas known to the experiment we prepare\n",
+        "experiment_params[\"data_stats\"] = data_stats\n",
+        "\n",
+        "# setting up training losses and model config (using default parameters)\n",
+        "loss_config = get_loss_config(**experiment_params)\n",
+        "model_config = get_model_config(**experiment_params)\n",
+        "gaussian_lik_config, noise_model_config, nm_lik_config = get_likelihood_config(\n",
+        "    **experiment_params\n",
+        ")\n",
+        "training_config = get_training_config(**experiment_params)\n",
+        "\n",
+        "# setting up learning rate scheduler and optimizer (using default parameters)\n",
+        "lr_scheduler_config = get_lr_scheduler_config(**experiment_params)\n",
+        "optimizer_config = get_optimizer_config(**experiment_params)\n",
+        "\n",
+        "# finally, assemble the full set of experiment configurations...\n",
+        "experiment_config = create_algorithm_config(\n",
+        "    algorithm=experiment_params[\"algorithm\"],\n",
+        "    loss_config=loss_config,\n",
+        "    model_config=model_config,\n",
+        "    gaussian_lik_config=gaussian_lik_config,\n",
+        "    nm_config=noise_model_config,\n",
+        "    nm_lik_config=nm_lik_config,\n",
+        "    lr_scheduler_config=lr_scheduler_config,\n",
+        "    optimizer_config=optimizer_config,\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Initialize the <nobr>Micro$\\mathbb{S}$plit</nobr> model to be trained.."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "model = VAEModule(algorithm_config=experiment_config)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### *Load checkpoint (optional and for you to implement)*\n",
+        "\n",
+        "<div class=\"alert alert-block alert-success\">\n",
+        "<b>Note:</b> If you would like to continue a previous training run or finetune a compatible pre-trained model, here would be a good place. You will need to figure out how to implement this for your use-case, but to give you a head-start, we left three potentially useful lines of code below.\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# from microsplit_reproducibility.notebook_utils.HT_LIF24 import load_pretrained_model\n",
+        "# ckpt_path = load_checkpoint_path(f\"./pretrained_checkpoints/{EXPOSURE_DURATION}/\", best=True)\n",
+        "# load_pretrained_model(model, ckpt_path)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Show some training data for a final check!\n",
+        "***Tip:*** we show you a few samples of the prepared training data. In case you don't like what you see, execute the cell again and other randomly chosen patches will be shown!"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "plot_input_patches(dataset=train_dset, num_channels=NUM_CHANNELS, num_samples=3, patch_size=128)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.3:** Train the prepared model!\n",
+        "***Note:*** if this takes too long, there were to places above where we gave you options to *(i)* reduce the amount of training data, and *(ii)* chose to train for fewer epochs. Revisit your choices if you want to!\n",
+        "\n",
+        "***Note:*** Depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> above.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### If you're not using MPS as your accelerator, ingore next cell"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# If you encounter float \"Cannot convert a MPS Tensor to float64\" error, run this cell\n",
+        "from microsplit_reproducibility.utils.utils import cast_model_floats\n",
+        "cast_model_floats(model)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# create the Trainer\n",
+        "trainer = Trainer(\n",
+        "    max_epochs=training_config.num_epochs,\n",
+        "    accelerator=\"gpu\",\n",
+        "    enable_progress_bar=True,\n",
+        "    callbacks=get_callbacks(\"./checkpoints/\"),\n",
+        "    precision=training_config.precision,\n",
+        "    gradient_clip_val=training_config.gradient_clip_val,\n",
+        "    gradient_clip_algorithm=training_config.gradient_clip_algorithm,\n",
+        ")\n",
+        "# start the training\n",
+        "trainer.fit(\n",
+        "    model=model,\n",
+        "    train_dataloaders=train_dloader,\n",
+        "    val_dataloaders=val_dloader,\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.4:** Predict and visualize results for validation data..."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Optional, reduce the validation dataset to speed up the evaluation\n",
+        "val_dset.reduce_data([0])"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "***Note*** Parameter `mmse_count` is responsible for how many samples are generated for each patch. The default value is 1, but in this case you might see stitching artifacts because each patch will be slightly different. You can increase this value to 10 to get a smoother image"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "scrolled": true
+      },
+      "source": [
+        "from microsplit_reproducibility.notebook_utils.custom_dataset_2D import (\n",
+        "    get_unnormalized_predictions,\n",
+        "    get_target,\n",
+        "    get_input,\n",
+        ")\n",
+        "\n",
+        "stitched_predictions, _, _ = get_unnormalized_predictions(\n",
+        "    model,\n",
+        "    val_dset,\n",
+        "    data_key=val_dset._fpath.name,\n",
+        "    mmse_count=experiment_params['mmse_count'],\n",
+        "    num_workers=0,\n",
+        "    batch_size=8\n",
+        ")\n",
+        "tar = get_target(val_dset)\n",
+        "\n",
+        "# get input as sum of the two channels\n",
+        "inp = get_input(val_dset).sum(-1)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Overview: visualize predictions on validation data..."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "_, ax = plt.subplots(2, 2, figsize=(20, 20))\n",
+        "ax[0, 0].imshow(tar[0, ..., 0], cmap=\"gray\")\n",
+        "ax[0, 0].set_title(\"Input ch1\")\n",
+        "ax[0, 1].imshow(tar[0, ..., 1], cmap=\"gray\")\n",
+        "ax[0, 1].set_title(\"Input ch2\")\n",
+        "ax[1, 0].imshow(stitched_predictions[0, ..., 0], cmap=\"gray\")\n",
+        "ax[1, 0].set_title(\"Prediction ch1\")\n",
+        "ax[1, 1].imshow(stitched_predictions[0, ..., 1], cmap=\"gray\")\n",
+        "ax[1, 1].set_title(\"Prediction ch2\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from microsplit_reproducibility.notebook_utils.custom_dataset_2D import full_frame_evaluation\n",
+        "\n",
+        "frame_idx = 0\n",
+        "assert frame_idx < len(stitched_predictions), f\"Frame index {frame_idx} out of bounds\"\n",
+        "full_frame_evaluation(stitched_predictions[frame_idx], tar[frame_idx], inp[frame_idx])"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Detailed view on some (foreground) locations...\n",
+        "Below, we show few random foreground locations and the corresponding <nobr>Micro$\\mathbb{S}$plit</nobr> predictions.\n",
+        "\n",
+        "As before, also here you can execute the cell multiple times and different randomly chosen locations will be plotted."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import numpy as np\n",
+        "from microsplit_reproducibility.utils.utils import clean_ax\n",
+        "from microsplit_reproducibility.notebook_utils.custom_dataset_2D import (\n",
+        "    pick_random_patches_with_content,\n",
+        ")\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "img_sz = 128\n",
+        "rand_locations = pick_random_patches_with_content(tar, 128)\n",
+        "h_start = rand_locations[\n",
+        "    2, 0\n",
+        "]  # np.random.randint(stitched_predictions.shape[1] - img_sz)\n",
+        "w_start = rand_locations[\n",
+        "    2, 1\n",
+        "]  # np.random.randint(stitched_predictions.shape[2] - img_sz)\n",
+        "\n",
+        "ncols = 4 + 1\n",
+        "nrows = min(len(rand_locations), 5)\n",
+        "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 3, nrows * 3))\n",
+        "\n",
+        "for i, (h_start, w_start) in enumerate(rand_locations[:nrows]):\n",
+        "    ax[i, 0].imshow(inp[0, h_start : h_start + img_sz, w_start : w_start + img_sz])\n",
+        "    for j in range(ncols // 2):\n",
+        "        vmin = stitched_predictions[\n",
+        "            0, h_start : h_start + img_sz, w_start : w_start + img_sz, j\n",
+        "        ].min()\n",
+        "        vmax = stitched_predictions[\n",
+        "            0, h_start : h_start + img_sz, w_start : w_start + img_sz, j\n",
+        "        ].max()\n",
+        "        ax[i, 2 * j + 1].imshow(\n",
+        "            tar[0, h_start : h_start + img_sz, w_start : w_start + img_sz, j],\n",
+        "            vmin=vmin,\n",
+        "            vmax=vmax,\n",
+        "        )\n",
+        "        ax[i, 2 * j + 2].imshow(\n",
+        "            stitched_predictions[\n",
+        "                0, h_start : h_start + img_sz, w_start : w_start + img_sz, j\n",
+        "            ],\n",
+        "            vmin=vmin,\n",
+        "            vmax=vmax,\n",
+        "        )\n",
+        "\n",
+        "ax[0, 0].set_title(\"Primary Input\")\n",
+        "for i in range(2):\n",
+        "    ax[0, 2 * i + 1].set_title(f\"Target Channel {i+1}\")\n",
+        "    ax[0, 2 * i + 2].set_title(f\"Predicted Channel {i+1}\")\n",
+        "\n",
+        "# reduce the spacing between the subplots\n",
+        "plt.subplots_adjust(wspace=0.03, hspace=0.03)\n",
+        "clean_ax(ax)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## *Optional:* manual inspection of the predictions\n",
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b> Task:</b> Set <i>y_start</i>, <i>x_start</i>, and <i>crop_size</i> to inspect the predictions at a  location of your choice.\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import numpy as np\n",
+        "\n",
+        "y_start = 600  # np.random.randint(stitched_predictions.shape[1] - crop_size)\n",
+        "x_start = 1150  # np.random.randint(stitched_predictions.shape[2] - crop_size)\n",
+        "crop_size = 128\n",
+        "\n",
+        "ncols = 3\n",
+        "nrows = 2\n",
+        "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 5, nrows * 5))\n",
+        "ax[0, 0].imshow(inp[0, y_start : y_start + crop_size, x_start : x_start + crop_size])\n",
+        "for i in range(ncols - 1):\n",
+        "    vmin = stitched_predictions[\n",
+        "        0, y_start : y_start + crop_size, x_start : x_start + crop_size, i\n",
+        "    ].min()\n",
+        "    vmax = stitched_predictions[\n",
+        "        0, y_start : y_start + crop_size, x_start : x_start + crop_size, i\n",
+        "    ].max()\n",
+        "    ax[0, i + 1].imshow(\n",
+        "        tar[0, y_start : y_start + crop_size, x_start : x_start + crop_size, i],\n",
+        "        vmin=vmin,\n",
+        "        vmax=vmax,\n",
+        "    )\n",
+        "    ax[1, i + 1].imshow(\n",
+        "        stitched_predictions[\n",
+        "            0, y_start : y_start + crop_size, x_start : x_start + crop_size, i\n",
+        "        ],\n",
+        "        vmin=vmin,\n",
+        "        vmax=vmax,\n",
+        "    )\n",
+        "\n",
+        "# disable the axis for ax[1,0]\n",
+        "ax[1, 0].axis(\"off\")\n",
+        "ax[0, 0].set_title(\"Input\")\n",
+        "ax[0, 1].set_title(\"Channel 1\")\n",
+        "ax[0, 2].set_title(\"Channel 2\")\n",
+        "# set y labels on the right for ax[0,2]\n",
+        "ax[0, 2].yaxis.set_label_position(\"right\")\n",
+        "ax[0, 2].set_ylabel(\"Target\")\n",
+        "\n",
+        "ax[1, 2].yaxis.set_label_position(\"right\")\n",
+        "ax[1, 2].set_ylabel(\"Predicted\")\n",
+        "\n",
+        "print(\"Here the crop you selected:\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# ***Optional Step 1.4:*** Posterior Sampling\n",
+        "For a given input patch, <nobr>Micro$\\mathbb{S}$plit</nobr> can generate multiple outputs. This is possible because <nobr>Micro$\\mathbb{S}$plit</nobr> is learning a full posterior of possible solutions, which is a quite powerful feature!\n",
+        "\n",
+        "As we elaborate in the <nobr>Micro$\\mathbb{S}$plit</nobr> paper and also later in the calibration notebook `03_calibration.ipynb`, this allows users to visually judge and even quantify the (data) uncertainty in the predictions their trained model makes.\n",
+        "\n",
+        "Below, we show two posterior samples and how much they differ for a few random foreground locations. Re-run the cell to see different randomly choosen locations and corresponding posterior samples."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from microsplit_reproducibility.notebook_utils.custom_dataset_2D import show_sampling\n",
+        "\n",
+        "imgsz = 3\n",
+        "ncols = 6\n",
+        "examplecount = 3\n",
+        "_, ax = plt.subplots(\n",
+        "    figsize=(imgsz * ncols, imgsz * 2 * examplecount),\n",
+        "    ncols=ncols,\n",
+        "    nrows=2 * examplecount,\n",
+        ")\n",
+        "\n",
+        "show_sampling(val_dset, model, ax=ax[:2])\n",
+        "show_sampling(val_dset, model, ax=ax[2:4])\n",
+        "show_sampling(val_dset, model, ax=ax[4:6])\n",
+        "plt.tight_layout()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### You are done here! 👍 Congratulations! 🎉"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "careamics",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.14"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Introduction - what does this notebook do?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Below, we will train a <nobr>Micro$\\mathbb{S}$plit</nobr> network for unmixing two superimposed channels for a custom dataset you provide. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Important:</b> How to organize your data for training a <nobr>Micro$\\mathbb{S}$plit</nobr> model\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> We provide example data for this set of notebooks also, but the intention is to let a user use their own data.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Below, we will train a <nobr>Micro$\\mathbb{S}$plit</nobr> network for unmixing two or more superimposed channels for a custom 2D dataset you provide. \n",
-    "\n",
-    "You should organize you dataset as follows:\n",
-    "- Create a `data` directory\n",
-    "- Create subdirectories `channel_1`, `channel_2`, etc, containing the channels you would like to unmix\n",
-    "- Make sure that the images have the same spatial size and each image has only 1 channel\n",
-    "\n",
-    "Your data directory should look like this:\n",
-    "```\n",
-    "you_data_path/\n",
-    "└── data\n",
-    "    ├── channel_1\n",
-    "    │   ├── image1.tiff\n",
-    "    │   ├── image2.tiff\n",
-    "    │   └── image3.tiff\n",
-    "    └── channel_2\n",
-    "    │   ├── image1.tiff\n",
-    "    │   ├── image2.tiff\n",
-    "    │   └── image3.tiff\n",
-    "    └── channel_n\n",
-    "    │   ├── image1.tiff\n",
-    "    │   ├── image2.tiff\n",
-    "    │   └── image3.tiff\n",
-    "```\n",
-    "\n",
-    "The mixed image used for splitting will be obtained artificially by a convex combination of the target channels.\n",
-    "\n",
-    "Let's begin!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Background: what is <nobr>Micro$\\mathbb{S}$plit</nobr> training all about?\n",
-    "Training is done in a supervised way. For every input patch, we have the two corresponding target patches using which we train our MicroSplit. \n",
-    "Besides the primary input patch, we also feed LC inputs to MicroSplit. We introduced LC inputs in [μSplit: efficient image decomposition for microscopy data](https://openaccess.thecvf.com/content/ICCV2023/papers/Ashesh_uSplit_Image_Decomposition_for_Fluorescence_Microscopy_ICCV_2023_paper.pdf), which enabled the network to understand the global spatial context around the input patch.\n",
-    "\n",
-    "To enable unsupervised denoising, we integrated the KL loss formulation and Noise models from our previous work [denoiSplit: a method for joint microscopy image splitting and unsupervised denoising](https://eccv.ecva.net/virtual/2024/poster/2538). \n",
-    "\n",
-    "The loss function for MicroSplit is a weighted average of denoiSplit loss and μSplit loss. For both denoiSplit and μSplit, their loss expression have two terms: KL divergence loss and likelihood loss. For more details, please refer to the respective papers."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Let's do it, let's train a <nobr>Micro$\\mathbb{S}$plit</nobr> Model!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**You are new to Jupyter notebooks?** Don't worry, if you take the time to read all our explanations, we will guide you through them and you will understand a lot. Still, you will likely end up less frustrated, if you do not even start with the ambition to interpret the purpose of every line of code.\n",
-    "Let's start with a nice example, the imports to enable the remainder of this notebook. Ignore it (unless you know what you are doing) and just click **⇧*Shift* + ⏎*Enter*** to execute this (and all other) code cells. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# importing all the things we need further down\n",
-    "import platform\n",
-    "from pathlib import Path\n",
-    "\n",
-    "import pooch\n",
-    "import matplotlib.pyplot as plt\n",
-    "from careamics.lightning import VAEModule\n",
-    "from pytorch_lightning import Trainer\n",
-    "from torch.utils.data import DataLoader\n",
-    "\n",
-    "from microsplit_reproducibility.configs.factory import (\n",
-    "    create_algorithm_config,\n",
-    "    get_likelihood_config,\n",
-    "    get_loss_config,\n",
-    "    get_model_config,\n",
-    "    get_optimizer_config,\n",
-    "    get_training_config,\n",
-    "    get_lr_scheduler_config,\n",
-    ")\n",
-    "from microsplit_reproducibility.utils.callbacks import get_callbacks\n",
-    "from microsplit_reproducibility.utils.io import load_checkpoint_path\n",
-    "from microsplit_reproducibility.datasets import create_train_val_datasets\n",
-    "from microsplit_reproducibility.utils.utils import plot_input_patches\n",
-    "\n",
-    "# Dataset specific imports...\n",
-    "from microsplit_reproducibility.configs.parameters.custom_dataset_2D import (\n",
-    "    get_microsplit_parameters\n",
-    ")\n",
-    "from microsplit_reproducibility.configs.data.custom_dataset_2D import get_data_configs\n",
-    "from microsplit_reproducibility.datasets.custom_dataset_2D import get_train_val_data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.1:** Data Preparation"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Since the channel unmixing capabilities of <nobr>Micro$\\mathbb{S}$plit</nobr> are trained in a supervised way, we must later feed *(i)* input images that contain both selected structures, and *(ii)* two seperate channels that show these two structures separately. As previosuly mentioned, the mixed input image is obtained synthetically by overlapping the other two channels."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Load example data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "DATA = pooch.create(\n",
-    "    path=f\"./data/\",\n",
-    "    base_url=f\"https://download.fht.org/jug/msplit/ht_lif24/data_tiff/\",\n",
-    "    registry={f\"ht_lif24_5ms_reduced.zip\": None},\n",
-    ")\n",
-    "for fname in DATA.registry:\n",
-    "    DATA.fetch(fname, processor=pooch.Unzip(), progressbar=True)\n",
-    "\n",
-    "DATA_PATH = DATA.abspath / (DATA.registry_files[0] + \".unzip/5ms/data/\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### OR set the path to your own data\n",
-    "Important: the path should end with `data/`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# DATA_PATH = Path(\"/my/path/data\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Setup the path to the noise models\n",
-    "This is the path to the noise models that you trained in the notebook **00_noisemodels.ipynb**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "NM_PATH = Path(\"./noise_models/\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Next, we load the image data to be processed\n",
-    "\n",
-    "***Note*** that depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> below.\n",
-    "\n",
-    "Number of epochs is set to 10, which usually allows to see decent results. However, for getting optimal performance you can increase it to 50.\n",
-    "\n",
-    "You also need to change the `num_channels` and `target_channels` parameters respectively for the `get_data_configs()` and the `get_microsplit_parameters` functions. These parameters have a similar meaning, i.e., they control the number of channels in the input data depending on how many channels you want to split.\n",
-    "\n",
-    "Finally, ensure that the `image_size` parameter (i.e., the patch size in (`Z`, `Y`, `X`) you want to use to train the model) is properly set given the size of your data and of you GPU."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "NUM_CHANNELS = 2\n",
-    "\"\"\"The number of channels considered for the splitting task.\"\"\"\n",
-    "BATCH_SIZE = 32\n",
-    "\"\"\"The batch size for training.\"\"\"\n",
-    "PATCH_SIZE = (64, 64)\n",
-    "\"\"\"The size of the patches fed to the network for training in (Y, X).\"\"\"\n",
-    "EPOCHS = 10\n",
-    "\"\"\"The number of epochs to train the network.\"\"\"\n",
-    "\n",
-    "assert len(PATCH_SIZE) == 2, \"PATCH_SIZE must be a tuple of length 2 (Y, X) since we are using 2D data.\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# setting up train, validation, and test data configs\n",
-    "train_data_config, val_data_config, test_data_config = get_data_configs(\n",
-    "    image_size=PATCH_SIZE,\n",
-    "    num_channels=NUM_CHANNELS\n",
-    ")\n",
-    "\n",
-    "# setting up MicroSplit parametrization\n",
-    "experiment_params = get_microsplit_parameters(\n",
-    "    algorithm=\"denoisplit\",\n",
-    "    img_size=PATCH_SIZE,\n",
-    "    batch_size=BATCH_SIZE,\n",
-    "    num_epochs=EPOCHS,\n",
-    "    multiscale_count=3,\n",
-    "    noise_model_path=NM_PATH,\n",
-    "    target_channels=NUM_CHANNELS,\n",
-    ")\n",
-    "\n",
-    "# create the dataset\n",
-    "train_dset, val_dset, _, data_stats = create_train_val_datasets(\n",
-    "    datapath=DATA_PATH,\n",
-    "    train_config=train_data_config,\n",
-    "    val_config=val_data_config,\n",
-    "    test_config=val_data_config,\n",
-    "    load_data_func=get_train_val_data,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Configure `num_workers`\n",
-    "In Windows and MacOS, setting `num_workers > 0` for dataloaders would cause out-of-memory issue and might crash the system."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_num_workers():\n",
-    "    \"\"\"Utility function to set num_workers based on OS.\"\"\"\n",
-    "    if platform.system() == \"Windows\" or platform.system() == \"Darwin\":\n",
-    "        return 0\n",
-    "    else:\n",
-    "        return 3  # or any other number suitable for your system\n",
-    "\n",
-    "experiment_params[\"num_workers\"] = get_num_workers()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "***Optional:*** inspect data configurations and <nobr>Micro$\\mathbb{S}$plit</nobr> config"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "do_show_configs = True\n",
-    "\n",
-    "if do_show_configs:\n",
-    "    print(\"FYI: train_data_config\")\n",
-    "    print(\"----------------------\")\n",
-    "    for cfg in train_data_config:\n",
-    "        print(cfg)\n",
-    "\n",
-    "    print(\"\\nFYI: experiment_params\")\n",
-    "    print(\"----------------------\")\n",
-    "    print(experiment_params)\n",
-    "else:\n",
-    "    print(\"You opted out of having all params printed... swiftly moving on... ;)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Final step: create Dataloaders for network training"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "train_dloader = DataLoader(\n",
-    "    train_dset,\n",
-    "    batch_size=experiment_params[\"batch_size\"],\n",
-    "    num_workers=experiment_params[\"num_workers\"],\n",
-    "    shuffle=True,\n",
-    ")\n",
-    "val_dloader = DataLoader(\n",
-    "    val_dset,\n",
-    "    batch_size=experiment_params[\"batch_size\"],\n",
-    "    num_workers=experiment_params[\"num_workers\"],\n",
-    "    shuffle=False,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.2:** Prepare <nobr>Micro$\\mathbb{S}$plit</nobr> Training\n",
-    "Next, we create all the configs for the upcoming network training run. These lines are not very intuitive and if you don't intend to dive really deep into CAREamics and the internals of <nobr>Micro$\\mathbb{S}$plit</nobr>, you might just execute these cells and move on."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# making our data_stas known to the experiment we prepare\n",
-    "experiment_params[\"data_stats\"] = data_stats\n",
-    "\n",
-    "# setting up training losses and model config (using default parameters)\n",
-    "loss_config = get_loss_config(**experiment_params)\n",
-    "model_config = get_model_config(**experiment_params)\n",
-    "gaussian_lik_config, noise_model_config, nm_lik_config = get_likelihood_config(\n",
-    "    **experiment_params\n",
-    ")\n",
-    "training_config = get_training_config(**experiment_params)\n",
-    "\n",
-    "# setting up learning rate scheduler and optimizer (using default parameters)\n",
-    "lr_scheduler_config = get_lr_scheduler_config(**experiment_params)\n",
-    "optimizer_config = get_optimizer_config(**experiment_params)\n",
-    "\n",
-    "# finally, assemble the full set of experiment configurations...\n",
-    "experiment_config = create_algorithm_config(\n",
-    "    algorithm=experiment_params[\"algorithm\"],\n",
-    "    loss_config=loss_config,\n",
-    "    model_config=model_config,\n",
-    "    gaussian_lik_config=gaussian_lik_config,\n",
-    "    nm_config=noise_model_config,\n",
-    "    nm_lik_config=nm_lik_config,\n",
-    "    lr_scheduler_config=lr_scheduler_config,\n",
-    "    optimizer_config=optimizer_config,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Initialize the <nobr>Micro$\\mathbb{S}$plit</nobr> model to be trained.."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model = VAEModule(algorithm_config=experiment_config)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### *Load checkpoint (optional and for you to implement)*\n",
-    "\n",
-    "<div class=\"alert alert-block alert-success\">\n",
-    "<b>Note:</b> If you would like to continue a previous training run or finetune a compatible pre-trained model, here would be a good place. You will need to figure out how to implement this for your use-case, but to give you a head-start, we left three potentially useful lines of code below.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# from microsplit_reproducibility.notebook_utils.HT_LIF24 import load_pretrained_model\n",
-    "# ckpt_path = load_checkpoint_path(f\"./pretrained_checkpoints/{EXPOSURE_DURATION}/\", best=True)\n",
-    "# load_pretrained_model(model, ckpt_path)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Show some training data for a final check!\n",
-    "***Tip:*** we show you a few samples of the prepared training data. In case you don't like what you see, execute the cell again and other randomly chosen patches will be shown!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_input_patches(dataset=train_dset, num_channels=NUM_CHANNELS, num_samples=3, patch_size=128)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.3:** Train the prepared model!\n",
-    "***Note:*** if this takes too long, there were to places above where we gave you options to *(i)* reduce the amount of training data, and *(ii)* chose to train for fewer epochs. Revisit your choices if you want to!\n",
-    "\n",
-    "***Note:*** Depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> above.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# create the Trainer\n",
-    "trainer = Trainer(\n",
-    "    max_epochs=training_config.num_epochs,\n",
-    "    accelerator=\"gpu\",\n",
-    "    enable_progress_bar=True,\n",
-    "    callbacks=get_callbacks(\"./checkpoints/\"),\n",
-    "    precision=training_config.precision,\n",
-    "    gradient_clip_val=training_config.gradient_clip_val,\n",
-    "    gradient_clip_algorithm=training_config.gradient_clip_algorithm,\n",
-    ")\n",
-    "# start the training\n",
-    "trainer.fit(\n",
-    "    model=model,\n",
-    "    train_dataloaders=train_dloader,\n",
-    "    val_dataloaders=val_dloader,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.4:** Predict and visualize results for validation data..."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Optional, reduce the validation dataset to speed up the evaluation\n",
-    "val_dset.reduce_data([0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "***Note*** Parameter `mmse_count` is responsible for how many samples are generated for each patch. The default value is 1, but in this case you might see stitching artifacts because each patch will be slightly different. You can increase this value to 10 to get a smoother image"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "from microsplit_reproducibility.notebook_utils.custom_dataset_2D import (\n",
-    "    get_unnormalized_predictions,\n",
-    "    get_target,\n",
-    "    get_input,\n",
-    ")\n",
-    "\n",
-    "stitched_predictions, _, _ = get_unnormalized_predictions(\n",
-    "    model,\n",
-    "    val_dset,\n",
-    "    data_key=val_dset._fpath.name,\n",
-    "    mmse_count=experiment_params['mmse_count'],\n",
-    "    num_workers=0,\n",
-    "    batch_size=8\n",
-    ")\n",
-    "tar = get_target(val_dset)\n",
-    "\n",
-    "# get input as sum of the two channels\n",
-    "inp = get_input(val_dset).sum(-1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Overview: visualize predictions on validation data..."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "_, ax = plt.subplots(2, 2, figsize=(20, 20))\n",
-    "ax[0, 0].imshow(tar[0, ..., 0], cmap=\"gray\")\n",
-    "ax[0, 0].set_title(\"Input ch1\")\n",
-    "ax[0, 1].imshow(tar[0, ..., 1], cmap=\"gray\")\n",
-    "ax[0, 1].set_title(\"Input ch2\")\n",
-    "ax[1, 0].imshow(stitched_predictions[0, ..., 0], cmap=\"gray\")\n",
-    "ax[1, 0].set_title(\"Prediction ch1\")\n",
-    "ax[1, 1].imshow(stitched_predictions[0, ..., 1], cmap=\"gray\")\n",
-    "ax[1, 1].set_title(\"Prediction ch2\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from microsplit_reproducibility.notebook_utils.custom_dataset_2D import full_frame_evaluation\n",
-    "\n",
-    "frame_idx = 0\n",
-    "assert frame_idx < len(stitched_predictions), f\"Frame index {frame_idx} out of bounds\"\n",
-    "full_frame_evaluation(stitched_predictions[frame_idx], tar[frame_idx], inp[frame_idx])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Detailed view on some (foreground) locations...\n",
-    "Below, we show few random foreground locations and the corresponding <nobr>Micro$\\mathbb{S}$plit</nobr> predictions.\n",
-    "\n",
-    "As before, also here you can execute the cell multiple times and different randomly chosen locations will be plotted."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "from microsplit_reproducibility.utils.utils import clean_ax\n",
-    "from microsplit_reproducibility.notebook_utils.custom_dataset_2D import (\n",
-    "    pick_random_patches_with_content,\n",
-    ")\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "img_sz = 128\n",
-    "rand_locations = pick_random_patches_with_content(tar, 128)\n",
-    "h_start = rand_locations[\n",
-    "    2, 0\n",
-    "]  # np.random.randint(stitched_predictions.shape[1] - img_sz)\n",
-    "w_start = rand_locations[\n",
-    "    2, 1\n",
-    "]  # np.random.randint(stitched_predictions.shape[2] - img_sz)\n",
-    "\n",
-    "ncols = 4 + 1\n",
-    "nrows = min(len(rand_locations), 5)\n",
-    "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 3, nrows * 3))\n",
-    "\n",
-    "for i, (h_start, w_start) in enumerate(rand_locations[:nrows]):\n",
-    "    ax[i, 0].imshow(inp[0, h_start : h_start + img_sz, w_start : w_start + img_sz])\n",
-    "    for j in range(ncols // 2):\n",
-    "        vmin = stitched_predictions[\n",
-    "            0, h_start : h_start + img_sz, w_start : w_start + img_sz, j\n",
-    "        ].min()\n",
-    "        vmax = stitched_predictions[\n",
-    "            0, h_start : h_start + img_sz, w_start : w_start + img_sz, j\n",
-    "        ].max()\n",
-    "        ax[i, 2 * j + 1].imshow(\n",
-    "            tar[0, h_start : h_start + img_sz, w_start : w_start + img_sz, j],\n",
-    "            vmin=vmin,\n",
-    "            vmax=vmax,\n",
-    "        )\n",
-    "        ax[i, 2 * j + 2].imshow(\n",
-    "            stitched_predictions[\n",
-    "                0, h_start : h_start + img_sz, w_start : w_start + img_sz, j\n",
-    "            ],\n",
-    "            vmin=vmin,\n",
-    "            vmax=vmax,\n",
-    "        )\n",
-    "\n",
-    "ax[0, 0].set_title(\"Primary Input\")\n",
-    "for i in range(2):\n",
-    "    ax[0, 2 * i + 1].set_title(f\"Target Channel {i+1}\")\n",
-    "    ax[0, 2 * i + 2].set_title(f\"Predicted Channel {i+1}\")\n",
-    "\n",
-    "# reduce the spacing between the subplots\n",
-    "plt.subplots_adjust(wspace=0.03, hspace=0.03)\n",
-    "clean_ax(ax)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## *Optional:* manual inspection of the predictions\n",
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b> Task:</b> Set <i>y_start</i>, <i>x_start</i>, and <i>crop_size</i> to inspect the predictions at a  location of your choice.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "\n",
-    "y_start = 600  # np.random.randint(stitched_predictions.shape[1] - crop_size)\n",
-    "x_start = 1150  # np.random.randint(stitched_predictions.shape[2] - crop_size)\n",
-    "crop_size = 128\n",
-    "\n",
-    "ncols = 3\n",
-    "nrows = 2\n",
-    "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 5, nrows * 5))\n",
-    "ax[0, 0].imshow(inp[0, y_start : y_start + crop_size, x_start : x_start + crop_size])\n",
-    "for i in range(ncols - 1):\n",
-    "    vmin = stitched_predictions[\n",
-    "        0, y_start : y_start + crop_size, x_start : x_start + crop_size, i\n",
-    "    ].min()\n",
-    "    vmax = stitched_predictions[\n",
-    "        0, y_start : y_start + crop_size, x_start : x_start + crop_size, i\n",
-    "    ].max()\n",
-    "    ax[0, i + 1].imshow(\n",
-    "        tar[0, y_start : y_start + crop_size, x_start : x_start + crop_size, i],\n",
-    "        vmin=vmin,\n",
-    "        vmax=vmax,\n",
-    "    )\n",
-    "    ax[1, i + 1].imshow(\n",
-    "        stitched_predictions[\n",
-    "            0, y_start : y_start + crop_size, x_start : x_start + crop_size, i\n",
-    "        ],\n",
-    "        vmin=vmin,\n",
-    "        vmax=vmax,\n",
-    "    )\n",
-    "\n",
-    "# disable the axis for ax[1,0]\n",
-    "ax[1, 0].axis(\"off\")\n",
-    "ax[0, 0].set_title(\"Input\")\n",
-    "ax[0, 1].set_title(\"Channel 1\")\n",
-    "ax[0, 2].set_title(\"Channel 2\")\n",
-    "# set y labels on the right for ax[0,2]\n",
-    "ax[0, 2].yaxis.set_label_position(\"right\")\n",
-    "ax[0, 2].set_ylabel(\"Target\")\n",
-    "\n",
-    "ax[1, 2].yaxis.set_label_position(\"right\")\n",
-    "ax[1, 2].set_ylabel(\"Predicted\")\n",
-    "\n",
-    "print(\"Here the crop you selected:\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# ***Optional Step 1.4:*** Posterior Sampling\n",
-    "For a given input patch, <nobr>Micro$\\mathbb{S}$plit</nobr> can generate multiple outputs. This is possible because <nobr>Micro$\\mathbb{S}$plit</nobr> is learning a full posterior of possible solutions, which is a quite powerful feature!\n",
-    "\n",
-    "As we elaborate in the <nobr>Micro$\\mathbb{S}$plit</nobr> paper and also later in the calibration notebook `03_calibration.ipynb`, this allows users to visually judge and even quantify the (data) uncertainty in the predictions their trained model makes.\n",
-    "\n",
-    "Below, we show two posterior samples and how much they differ for a few random foreground locations. Re-run the cell to see different randomly choosen locations and corresponding posterior samples."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from microsplit_reproducibility.notebook_utils.custom_dataset_2D import show_sampling\n",
-    "\n",
-    "imgsz = 3\n",
-    "ncols = 6\n",
-    "examplecount = 3\n",
-    "_, ax = plt.subplots(\n",
-    "    figsize=(imgsz * ncols, imgsz * 2 * examplecount),\n",
-    "    ncols=ncols,\n",
-    "    nrows=2 * examplecount,\n",
-    ")\n",
-    "\n",
-    "show_sampling(val_dset, model, ax=ax[:2])\n",
-    "show_sampling(val_dset, model, ax=ax[2:4])\n",
-    "show_sampling(val_dset, model, ax=ax[4:6])\n",
-    "plt.tight_layout()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### You are done here! 👍 Congratulations! 🎉"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "careamics",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.14"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 4
 }

--- a/examples/3D/HT_H24/01_train.ipynb
+++ b/examples/3D/HT_H24/01_train.ipynb
@@ -1,722 +1,740 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1:** Training a <nobr>Micro$\\mathbb{S}$plit</nobr> Model"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1:** Training a <nobr>Micro$\\mathbb{S}$plit</nobr> Model"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Introduction - what does this notebook do?"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b>Note:</b> Despite network training arguably being the most important step, the execution of this notebook is optional. If you do not run this notebook, in Step 2 (prediction) we offer you to use pretrained model checkpoints. Like in any respected cooking show: \"we have already prepared someting before the show\"... 😉\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Below, we will train a <nobr>Micro$\\mathbb{S}$plit</nobr> network for unmixing two superimposed channels from our HT-H24 dataset: SOX2 and MAP2 channels."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Background: what is <nobr>Micro$\\mathbb{S}$plit</nobr> training all about?\n",
+        "Training is done in a supervised way. For every input patch, we have the two corresponding target patches using which we train our MicroSplit. \n",
+        "Besides the primary input patch, we also feed LC inputs to MicroSplit. We introduced LC inputs in [μSplit: efficient image decomposition for microscopy data](https://openaccess.thecvf.com/content/ICCV2023/papers/Ashesh_uSplit_Image_Decomposition_for_Fluorescence_Microscopy_ICCV_2023_paper.pdf), which enabled the network to understand the global spatial context around the input patch.\n",
+        "\n",
+        "To enable unsupervised denoising, we integrated the KL loss formulation and Noise models from our previous work [denoiSplit: a method for joint microscopy image splitting and unsupervised denoising](https://eccv.ecva.net/virtual/2024/poster/2538). \n",
+        "\n",
+        "The loss function for MicroSplit is a weighted average of denoiSplit loss and μSplit loss. For both denoiSplit and μSplit, their loss expression have two terms: KL divergence loss and likelihood loss. For more details, please refer to the respective papers."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Let's do it, let's train a <nobr>Micro$\\mathbb{S}$plit</nobr> Model!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**You are new to Jupyter notebooks?** Don't worry, if you take the time to read all our explanations, we will guide you through them and you will understand a lot. Still, you will likely end up less frustrated, if you do not even start with the ambition to interpret the purpose of every line of code.\n",
+        "Let's start with a nice example, the imports to enable the remainder of this notebook. Ignore it (unless you know what you are doing) and just click **⇧*Shift* + ⏎*Enter*** to execute this (and all other) code cells. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# importing all the things we need further down\n",
+        "import platform\n",
+        "import pooch\n",
+        "from pathlib import Path\n",
+        "from pytorch_lightning import Trainer\n",
+        "from torch.utils.data import DataLoader\n",
+        "from careamics.lightning import VAEModule\n",
+        "\n",
+        "from microsplit_reproducibility.configs.factory import (\n",
+        "    create_algorithm_config,\n",
+        "    get_likelihood_config,\n",
+        "    get_loss_config,\n",
+        "    get_model_config,\n",
+        "    get_optimizer_config,\n",
+        "    get_training_config,\n",
+        "    get_lr_scheduler_config,\n",
+        ")\n",
+        "from microsplit_reproducibility.utils.callbacks import get_callbacks\n",
+        "from microsplit_reproducibility.utils.io import load_checkpoint, load_checkpoint_path\n",
+        "from microsplit_reproducibility.datasets import create_train_val_datasets\n",
+        "from microsplit_reproducibility.utils.utils import (\n",
+        "    plot_training_metrics,\n",
+        "    plot_input_patches_3d,\n",
+        "    plot_training_outputs,\n",
+        ")\n",
+        "\n",
+        "# Dataset specific imports...\n",
+        "from microsplit_reproducibility.configs.parameters.HT_H24 import get_microsplit_parameters\n",
+        "from microsplit_reproducibility.configs.data.HT_H24 import get_data_configs\n",
+        "from microsplit_reproducibility.datasets.HT_H24 import get_train_val_data"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.1:** Data Preparation\n",
+        "\n",
+        "If you want to use your own data, you will have to change this section in an appropriate way.\n",
+        "\n",
+        "Without any special modifications, **the following few steps will first choose which subset of the *HT_LIF24* dataset to use and then train a <nobr>Micro$\\mathbb{S}$plit</nobr> Model on this data**.\n",
+        "\n",
+        "The reason to pick a subset of the *HT_LIF24* dataset is, that we recorded this data with multiple possible learning tasks in mind. Check the <nobr>Micro$\\mathbb{S}$plit</nobr> paper for all the details.\n",
+        "\n",
+        "This logic you find below will likely also apply to your needs when training on your own data (in case this is what you are after). Still, don't shy away from deviating from the code you find below..."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Select the two channels you want a Noise Model for, and the exposure time (SNR) of these channel acquisitions you want to use...\n",
+        "To make things more human readable, we use the utility classes we defined above."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Next, we double check that you made a sound choice... no offense! 😉<br>\n",
+        "If you execute the next cell and nothing happens it means all is going well. "
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "The next line is likely a bit confusing at first.\n",
+        "\n",
+        "Since the channel unmixing capabilities of <nobr>Micro$\\mathbb{S}$plit</nobr> are trained in a supervised way, we must later feed *(i)* input images that contain both selected structures, and *(ii)* two seperate channels that show these two structures sepaerately.\n",
+        "\n",
+        "Above, we made you choose the two seperated strucutures, but we now must also sum up those images into the superimposed input images. We could do so 'on-the-fly', but that would take a while. Hence, we have already done so for all combinations of structures you can find in this dataset and ***the next cell simply figures out where the appropriately prepared data can be found***.\n",
+        "\n",
+        "In case you want to use your own data, you will have to rethink the way you end up having your data prepared!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Download the data you need (given your choices from above)\n",
+        "Depending on your internet connection, this will take a while...\n",
+        "\n",
+        "Note that appropriate noise models will only be downloaded if they were not created by executing the notebook `00_noisemodels.ipynb`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "DATA = pooch.create(\n",
+        "    path=\"./data\",\n",
+        "    base_url=\"https://download.fht.org/jug/msplit/ht_h24/data\",\n",
+        "    registry={f\"ht_h24.zip\": None},\n",
+        ")\n",
+        "\n",
+        "NOISE_MODELS = pooch.create(\n",
+        "    path=f\"./noise_models/\",\n",
+        "    base_url=f\"https://download.fht.org/jug/msplit/ht_h24/noise_models/\",\n",
+        "    registry={\n",
+        "        f\"noise_model_Ch0.npz\": None,\n",
+        "        f\"noise_model_Ch1.npz\": None,\n",
+        "    },\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Note that the following notebook will download all you need. In case you see no messages announcing any downloads, you already have this data in the notebook folder."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "for fname in NOISE_MODELS.registry:\n",
+        "    NOISE_MODELS.fetch(fname, progressbar=True)\n",
+        "print('---------')\n",
+        "for fname in DATA.registry:\n",
+        "    DATA.fetch(fname, processor=pooch.Unzip(), progressbar=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Next, we load the image data to be processed\n",
+        "\n",
+        "Note that depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> below.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# setting up train, validation, and test data configs\n",
+        "train_data_config, val_data_config, test_data_config = get_data_configs()\n",
+        "# setting up MicroSplit parametrization\n",
+        "experiment_params = get_microsplit_parameters(nm_path=NOISE_MODELS.path, batch_size=32)\n",
+        "\n",
+        "# start the download of required files\n",
+        "train_dset, val_dset, _, data_stats = create_train_val_datasets(\n",
+        "    datapath=DATA.path / f\"ht_h24.zip.unzip/ht_h24\",\n",
+        "    train_config=train_data_config,\n",
+        "    val_config=val_data_config,\n",
+        "    test_config=val_data_config,\n",
+        "    load_data_func=get_train_val_data,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Configure `num_workers`\n",
+        "In Windows and MacOS, setting `num_workers > 0` for dataloaders would cause out-of-memory issue and might crash the system."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def get_num_workers():\n",
+        "    \"\"\"Utility function to set num_workers based on OS.\"\"\"\n",
+        "    if platform.system() == \"Windows\" or platform.system() == \"Darwin\":\n",
+        "        return 0\n",
+        "    else:\n",
+        "        return 3  # or any other number suitable for your system\n",
+        "\n",
+        "experiment_params[\"num_workers\"] = get_num_workers()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "***Optional:*** inspect data configurations and <nobr>Micro$\\mathbb{S}$plit</nobr> config"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "do_show_configs = True\n",
+        "\n",
+        "if do_show_configs:\n",
+        "    print('FYI: train_data_config')\n",
+        "    print('----------------------')\n",
+        "    for cfg in train_data_config:\n",
+        "        print(cfg)\n",
+        "\n",
+        "    print('\\nFYI: experiment_params')\n",
+        "    print('----------------------')\n",
+        "    print(experiment_params)\n",
+        "else:\n",
+        "    print('You opted out of having all params printed... swiftly moving on... ;)')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Wanna trade speed for model quality? (1/2)\n",
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b>Note:</b> If you just want to get an idea of the process of training <nobr>Micro$\\mathbb{S}$plit</nobr> and you do not intend to get best-possible results, feel invited to crop down on the training data to be used further down. <i><b>Do not do this</b> if you intend to train a competitive model!!!</i>\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# If True, training and validation data will be reduced to only \n",
+        "# consisting of 2 and 1 frames, respectively.\n",
+        "reduce_data = True\n",
+        "\n",
+        "if reduce_data:\n",
+        "    print(\"Using REDUCED training and validation data for quick'n'dirty testing!\")\n",
+        "    train_dset.reduce_data([0,1])\n",
+        "    val_dset.reduce_data([0])\n",
+        "else:\n",
+        "    print('Using the full set of training and validation data!')\n",
+        "print(f'(This are {train_dset.get_num_frames()} and {val_dset.get_num_frames()} frames, respectively.)') "
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Final step: create Dataloaders for network training"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "train_dloader = DataLoader(\n",
+        "    train_dset,\n",
+        "    batch_size=experiment_params[\"batch_size\"],\n",
+        "    num_workers=experiment_params[\"num_workers\"],\n",
+        "    shuffle=True,\n",
+        ")\n",
+        "val_dloader = DataLoader(\n",
+        "    val_dset,\n",
+        "    batch_size=experiment_params[\"batch_size\"],\n",
+        "    num_workers=experiment_params[\"num_workers\"],\n",
+        "    shuffle=False,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.2:** Prepare <nobr>Micro$\\mathbb{S}$plit</nobr> Training\n",
+        "Next, we create all the configs for the upcoming network training run. These lines are not very intuitive and if you don't intend to dive really deep into CAREamics and the internals of <nobr>Micro$\\mathbb{S}$plit</nobr>, you might just execute these cells and move on."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# making our data_stas known to the experiment we prepare\n",
+        "experiment_params[\"data_stats\"] = data_stats\n",
+        "\n",
+        "# setting up training losses and model config (using default parameters)\n",
+        "loss_config = get_loss_config(**experiment_params)\n",
+        "model_config = get_model_config(**experiment_params)\n",
+        "gaussian_lik_config, noise_model_config, nm_lik_config = get_likelihood_config(\n",
+        "    **experiment_params\n",
+        ")\n",
+        "training_config = get_training_config(**experiment_params)\n",
+        "\n",
+        "# setting up learning rate scheduler and optimizer (using default parameters)\n",
+        "lr_scheduler_config = get_lr_scheduler_config(**experiment_params)\n",
+        "optimizer_config = get_optimizer_config(**experiment_params)\n",
+        "\n",
+        "# finally, assemble the full set of experiment configurations...\n",
+        "experiment_config = create_algorithm_config(\n",
+        "    algorithm=experiment_params[\"algorithm\"],\n",
+        "    loss_config=loss_config,\n",
+        "    model_config=model_config,\n",
+        "    gaussian_lik_config=gaussian_lik_config,\n",
+        "    nm_config=noise_model_config,\n",
+        "    nm_lik_config=nm_lik_config,\n",
+        "    lr_scheduler_config=lr_scheduler_config,\n",
+        "    optimizer_config=optimizer_config,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Wanna trade speed for model quality? (2/2)\n",
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b>Note:</b> Similar to above, if you simply want to go over this notebook quickly and you don't care about training a competitive model, set <i>`reduce_training_epochs=True`</i> in the cell below. \n",
+        "\n",
+        "Note that if <i> reduce_training_epochs </i> is set to <i>False </i>, the default number of epochs is 400. However, early stopping will be invoked when the loss is no longer decreasing, so the actual number of epochs trained will most likely be less than 400.\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "reduce_training_epochs = True\n",
+        "\n",
+        "# if True, train for only 10 epochs (quick'n'dirty testing mode)\n",
+        "if reduce_training_epochs:\n",
+        "    training_config.num_epochs = 10\n",
+        "\n",
+        "print(f'Will train for {training_config.num_epochs} epochs!')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Initialize the <nobr>Micro$\\mathbb{S}$plit</nobr> model to be trained.."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "model = VAEModule(algorithm_config=experiment_config)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### *Load checkpoint (optional and for you to implement)*\n",
+        "\n",
+        "<div class=\"alert alert-block alert-success\">\n",
+        "<b>Note:</b> If you would like to continue a previous training run or finetune a compatible pre-trained model, here would be a good place. You will need to figure out how to implement this for your use-case, but to give you a head-start, we left three potentially useful lines of code below.\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# from microsplit_reproducibility.notebook_utils.HT_LIF24 import load_pretrained_model\n",
+        "# ckpt_path = load_checkpoint_path(f\"./pretrained_checkpoints/{EXPOSURE_DURATION}/\", best=True)\n",
+        "# load_pretrained_model(model, ckpt_path)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Show some training data for a final check!\n",
+        "***Tip:*** we show you a few samples of the prepared training data. In case you don't like what you see, execute the cell again and other randomly chosen patches will be shown!"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "plot_input_patches_3d(dataset=train_dset, num_channels=2, num_samples=3, patch_size=128)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.3:** Train the prepared model!\n",
+        "***Note:*** if this takes too long, there were to places above where we gave you options to *(i)* reduce the amount of training data, and *(ii)* chose to train for fewer epochs. Revisit your choices if you want to!\n",
+        "\n",
+        "***Note:*** Depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> above.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### If you're not using MPS as your accelerator, ingore next cell"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# If you encounter float \"Cannot convert a MPS Tensor to float64\" error, run this cell\n",
+        "from microsplit_reproducibility.utils.utils import cast_model_floats\n",
+        "cast_model_floats(model)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# create a CAREamics 'Trainer'\n",
+        "trainer = Trainer(\n",
+        "    max_epochs=training_config.num_epochs,\n",
+        "    # NOTE: if you are on a mac swap the accelerator to \"mps\"\n",
+        "    # accelerator=“mps”,\n",
+        "    accelerator=\"gpu\",\n",
+        "    enable_progress_bar=True,\n",
+        "    callbacks=get_callbacks(f\"./checkpoints/\"),\n",
+        "    precision=training_config.precision,\n",
+        "    gradient_clip_val=training_config.gradient_clip_val,\n",
+        "    gradient_clip_algorithm=training_config.gradient_clip_algorithm,\n",
+        ")\n",
+        "# start the training - yay!\n",
+        "trainer.fit(\n",
+        "    model=model,\n",
+        "    train_dataloaders=train_dloader,\n",
+        "    val_dataloaders=val_dloader,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Show training loss curves...\n",
+        "Below, we plot for each epoch of your training run the *(i)* training reconstruction loss, *(ii)* training KL divergence loss, *(iii)* validation reconstruction loss, and *(iv)* validation PSNR. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pandas import read_csv\n",
+        "from microsplit_reproducibility.notebook_utils.HT_LIF24 import find_recent_metrics, plot_metrics\n",
+        "df = read_csv(find_recent_metrics())\n",
+        "plot_metrics(df)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.4:** Predict and visualize results for validation data..."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "scrolled": true
+      },
+      "outputs": [],
+      "source": [
+        "from microsplit_reproducibility.notebook_utils.HT_H24 import (\n",
+        "    get_unnormalized_predictions,\n",
+        "    get_target,\n",
+        "    get_input,\n",
+        ")\n",
+        "\n",
+        "stitched_predictions, _, _ = get_unnormalized_predictions(\n",
+        "    model,\n",
+        "    val_dset,\n",
+        "    mmse_count=experiment_params[\"mmse_count\"],\n",
+        "    num_workers=0,\n",
+        "    batch_size=8,\n",
+        ")\n",
+        "tar = get_target(val_dset)\n",
+        "inp = get_input(val_dset)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Overview: visualize predictions on validation data..."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from microsplit_reproducibility.notebook_utils.HT_H24 import full_frame_evaluation\n",
+        "frame_idx = 0\n",
+        "assert frame_idx < len(stitched_predictions), f\"Frame index {frame_idx} out of bounds\"\n",
+        "full_frame_evaluation(stitched_predictions[frame_idx], tar[frame_idx])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Detailed view on some (foreground) locations...\n",
+        "Below, we show few random foreground locations and the corresponding <nobr>Micro$\\mathbb{S}$plit</nobr> predictions.\n",
+        "\n",
+        "As before, also here you can execute the cell multiple times and different randomly chosen locations will be plotted."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "from microsplit_reproducibility.utils.utils import clean_ax\n",
+        "from microsplit_reproducibility.notebook_utils.HT_H24 import pick_random_patches_with_content\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "img_sz = 64\n",
+        "rand_locations = pick_random_patches_with_content(tar, img_sz)\n",
+        "\n",
+        "h_start = rand_locations[2, 1] #np.random.randint(stitched_predictions.shape[1] - img_sz)\n",
+        "w_start = rand_locations[2, 2] #np.random.randint(stitched_predictions.shape[2] - img_sz)\n",
+        "\n",
+        "ncols = 5\n",
+        "nrows = min(len(rand_locations), 5)\n",
+        "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 3, nrows * 3))\n",
+        "\n",
+        "for i, (z_idx, h_start, w_start) in enumerate(rand_locations[:nrows]):\n",
+        "    ax[i, 0].imshow(inp[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, 0])\n",
+        "    for j in range(ncols//2):\n",
+        "        vmin = stitched_predictions[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j].min()\n",
+        "        vmax = stitched_predictions[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j].max()\n",
+        "        ax[i, 2*j+1].imshow(tar[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j], vmin=vmin, vmax=vmax)\n",
+        "        ax[i, 2*j+2].imshow(stitched_predictions[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j], vmin=vmin, vmax=vmax)\n",
+        "\n",
+        "ax[0,0].set_title('Primary Input')\n",
+        "for i in range(2):\n",
+        "    ax[0, 2*i+1].set_title(f'Target Channel {i+1}')\n",
+        "    ax[0, 2*i+2].set_title(f'Predicted Channel {i+1}')\n",
+        "\n",
+        "# reduce the spacing between the subplots\n",
+        "plt.subplots_adjust(wspace=0.03, hspace=0.03)\n",
+        "clean_ax(ax)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## *Optional:* manual inspection of the predictions\n",
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b> Task:</b> Set <i>y_start</i>, <i>x_start</i>, and <i>crop_size</i> to inspect the predictions at a  location of your choice.\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "y_start = 100  #np.random.randint(stitched_predictions.shape[1] - crop_size)\n",
+        "x_start = 100 #np.random.randint(stitched_predictions.shape[2] - crop_size)\n",
+        "z_idx = 0\n",
+        "\n",
+        "crop_size = 128\n",
+        "\n",
+        "ncols = 3\n",
+        "nrows = 2\n",
+        "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 5, nrows * 5))\n",
+        "ax[0,0].imshow(inp[0, z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, 0])\n",
+        "ax[1,0].imshow(inp[0, z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, 1])\n",
+        "\n",
+        "for i in range(ncols -1):\n",
+        "    vmin = stitched_predictions[0, z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i].min()\n",
+        "    vmax = stitched_predictions[0, z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i].max()\n",
+        "    ax[0,i+1].imshow(tar[0,z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i], vmin=vmin, vmax=vmax)\n",
+        "    ax[1,i+1].imshow(stitched_predictions[0, z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i], vmin=vmin, vmax=vmax)\n",
+        "\n",
+        "# disable the axis for ax[1,0]\n",
+        "ax[1,0].axis('off')\n",
+        "ax[0,0].set_title(\"Input\")\n",
+        "ax[0,1].set_title(\"Channel 1\")\n",
+        "ax[0,2].set_title(\"Channel 2\")\n",
+        "# set y labels on the right for ax[0,2]\n",
+        "ax[0,2].yaxis.set_label_position(\"right\")\n",
+        "ax[0,2].set_ylabel(\"Target\")\n",
+        "\n",
+        "ax[1,2].yaxis.set_label_position(\"right\")\n",
+        "ax[1,2].set_ylabel(\"Predicted\")\n",
+        "\n",
+        "print('Here the crop you selected:')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# ***Optional Step 1.4:*** Posterior Sampling\n",
+        "For a given input patch, <nobr>Micro$\\mathbb{S}$plit</nobr> can generate multiple outputs. This is possible because <nobr>Micro$\\mathbb{S}$plit</nobr> is learning a full posterior of possible solutions, which is a quite powerful feature!\n",
+        "\n",
+        "As we elaborate in the <nobr>Micro$\\mathbb{S}$plit</nobr> paper and also later in the calibration notebook `03_calibration.ipynb`, this allows users to visually judge and even quantify the (data) uncertainty in the predictions their trained model makes.\n",
+        "\n",
+        "Below, we show two posterior samples and how much they differ for a few random foreground locations. Re-run the cell to see different randomly choosen locations and corresponding posterior samples."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from microsplit_reproducibility.notebook_utils.HT_H24 import show_sampling\n",
+        "imgsz = 3\n",
+        "ncols = 6\n",
+        "examplecount = 3\n",
+        "_,ax = plt.subplots(figsize=(imgsz*ncols, imgsz*2*examplecount), ncols=ncols, nrows=2*examplecount)\n",
+        "\n",
+        "show_sampling(val_dset, model, ax=ax[:2])\n",
+        "show_sampling(val_dset, model, ax=ax[2:4])\n",
+        "show_sampling(val_dset, model, ax=ax[4:6])\n",
+        "plt.tight_layout()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### You are done here! 👍 Congratulations! 🎉"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "careamics",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.14"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Introduction - what does this notebook do?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> Despite network training arguably being the most important step, the execution of this notebook is optional. If you do not run this notebook, in Step 2 (prediction) we offer you to use pretrained model checkpoints. Like in any respected cooking show: \"we have already prepared someting before the show\"... 😉\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Below, we will train a <nobr>Micro$\\mathbb{S}$plit</nobr> network for unmixing two superimposed channels from our HT-H24 dataset: SOX2 and MAP2 channels."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Background: what is <nobr>Micro$\\mathbb{S}$plit</nobr> training all about?\n",
-    "Training is done in a supervised way. For every input patch, we have the two corresponding target patches using which we train our MicroSplit. \n",
-    "Besides the primary input patch, we also feed LC inputs to MicroSplit. We introduced LC inputs in [μSplit: efficient image decomposition for microscopy data](https://openaccess.thecvf.com/content/ICCV2023/papers/Ashesh_uSplit_Image_Decomposition_for_Fluorescence_Microscopy_ICCV_2023_paper.pdf), which enabled the network to understand the global spatial context around the input patch.\n",
-    "\n",
-    "To enable unsupervised denoising, we integrated the KL loss formulation and Noise models from our previous work [denoiSplit: a method for joint microscopy image splitting and unsupervised denoising](https://eccv.ecva.net/virtual/2024/poster/2538). \n",
-    "\n",
-    "The loss function for MicroSplit is a weighted average of denoiSplit loss and μSplit loss. For both denoiSplit and μSplit, their loss expression have two terms: KL divergence loss and likelihood loss. For more details, please refer to the respective papers."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Let's do it, let's train a <nobr>Micro$\\mathbb{S}$plit</nobr> Model!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**You are new to Jupyter notebooks?** Don't worry, if you take the time to read all our explanations, we will guide you through them and you will understand a lot. Still, you will likely end up less frustrated, if you do not even start with the ambition to interpret the purpose of every line of code.\n",
-    "Let's start with a nice example, the imports to enable the remainder of this notebook. Ignore it (unless you know what you are doing) and just click **⇧*Shift* + ⏎*Enter*** to execute this (and all other) code cells. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# importing all the things we need further down\n",
-    "import platform\n",
-    "import pooch\n",
-    "from pathlib import Path\n",
-    "from pytorch_lightning import Trainer\n",
-    "from torch.utils.data import DataLoader\n",
-    "from careamics.lightning import VAEModule\n",
-    "\n",
-    "from microsplit_reproducibility.configs.factory import (\n",
-    "    create_algorithm_config,\n",
-    "    get_likelihood_config,\n",
-    "    get_loss_config,\n",
-    "    get_model_config,\n",
-    "    get_optimizer_config,\n",
-    "    get_training_config,\n",
-    "    get_lr_scheduler_config,\n",
-    ")\n",
-    "from microsplit_reproducibility.utils.callbacks import get_callbacks\n",
-    "from microsplit_reproducibility.utils.io import load_checkpoint, load_checkpoint_path\n",
-    "from microsplit_reproducibility.datasets import create_train_val_datasets\n",
-    "from microsplit_reproducibility.utils.utils import (\n",
-    "    plot_training_metrics,\n",
-    "    plot_input_patches_3d,\n",
-    "    plot_training_outputs,\n",
-    ")\n",
-    "\n",
-    "# Dataset specific imports...\n",
-    "from microsplit_reproducibility.configs.parameters.HT_H24 import get_microsplit_parameters\n",
-    "from microsplit_reproducibility.configs.data.HT_H24 import get_data_configs\n",
-    "from microsplit_reproducibility.datasets.HT_H24 import get_train_val_data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.1:** Data Preparation\n",
-    "\n",
-    "If you want to use your own data, you will have to change this section in an appropriate way.\n",
-    "\n",
-    "Without any special modifications, **the following few steps will first choose which subset of the *HT_LIF24* dataset to use and then train a <nobr>Micro$\\mathbb{S}$plit</nobr> Model on this data**.\n",
-    "\n",
-    "The reason to pick a subset of the *HT_LIF24* dataset is, that we recorded this data with multiple possible learning tasks in mind. Check the <nobr>Micro$\\mathbb{S}$plit</nobr> paper for all the details.\n",
-    "\n",
-    "This logic you find below will likely also apply to your needs when training on your own data (in case this is what you are after). Still, don't shy away from deviating from the code you find below..."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Select the two channels you want a Noise Model for, and the exposure time (SNR) of these channel acquisitions you want to use...\n",
-    "To make things more human readable, we use the utility classes we defined above."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Next, we double check that you made a sound choice... no offense! 😉<br>\n",
-    "If you execute the next cell and nothing happens it means all is going well. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The next line is likely a bit confusing at first.\n",
-    "\n",
-    "Since the channel unmixing capabilities of <nobr>Micro$\\mathbb{S}$plit</nobr> are trained in a supervised way, we must later feed *(i)* input images that contain both selected structures, and *(ii)* two seperate channels that show these two structures sepaerately.\n",
-    "\n",
-    "Above, we made you choose the two seperated strucutures, but we now must also sum up those images into the superimposed input images. We could do so 'on-the-fly', but that would take a while. Hence, we have already done so for all combinations of structures you can find in this dataset and ***the next cell simply figures out where the appropriately prepared data can be found***.\n",
-    "\n",
-    "In case you want to use your own data, you will have to rethink the way you end up having your data prepared!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Download the data you need (given your choices from above)\n",
-    "Depending on your internet connection, this will take a while...\n",
-    "\n",
-    "Note that appropriate noise models will only be downloaded if they were not created by executing the notebook `00_noisemodels.ipynb`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "DATA = pooch.create(\n",
-    "    path=\"./data\",\n",
-    "    base_url=\"https://download.fht.org/jug/msplit/ht_h24/data\",\n",
-    "    registry={f\"ht_h24.zip\": None},\n",
-    ")\n",
-    "\n",
-    "NOISE_MODELS = pooch.create(\n",
-    "    path=f\"./noise_models/\",\n",
-    "    base_url=f\"https://download.fht.org/jug/msplit/ht_h24/noise_models/\",\n",
-    "    registry={\n",
-    "        f\"noise_model_Ch0.npz\": None,\n",
-    "        f\"noise_model_Ch1.npz\": None,\n",
-    "    },\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that the following notebook will download all you need. In case you see no messages announcing any downloads, you already have this data in the notebook folder."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for fname in NOISE_MODELS.registry:\n",
-    "    NOISE_MODELS.fetch(fname, progressbar=True)\n",
-    "print('---------')\n",
-    "for fname in DATA.registry:\n",
-    "    DATA.fetch(fname, processor=pooch.Unzip(), progressbar=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Next, we load the image data to be processed\n",
-    "\n",
-    "Note that depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> below.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# setting up train, validation, and test data configs\n",
-    "train_data_config, val_data_config, test_data_config = get_data_configs()\n",
-    "# setting up MicroSplit parametrization\n",
-    "experiment_params = get_microsplit_parameters(nm_path=NOISE_MODELS.path, batch_size=32)\n",
-    "\n",
-    "# start the download of required files\n",
-    "train_dset, val_dset, _, data_stats = create_train_val_datasets(\n",
-    "    datapath=DATA.path / f\"ht_h24.zip.unzip/ht_h24\",\n",
-    "    train_config=train_data_config,\n",
-    "    val_config=val_data_config,\n",
-    "    test_config=val_data_config,\n",
-    "    load_data_func=get_train_val_data,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Configure `num_workers`\n",
-    "In Windows and MacOS, setting `num_workers > 0` for dataloaders would cause out-of-memory issue and might crash the system."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_num_workers():\n",
-    "    \"\"\"Utility function to set num_workers based on OS.\"\"\"\n",
-    "    if platform.system() == \"Windows\" or platform.system() == \"Darwin\":\n",
-    "        return 0\n",
-    "    else:\n",
-    "        return 3  # or any other number suitable for your system\n",
-    "\n",
-    "experiment_params[\"num_workers\"] = get_num_workers()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "***Optional:*** inspect data configurations and <nobr>Micro$\\mathbb{S}$plit</nobr> config"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "do_show_configs = True\n",
-    "\n",
-    "if do_show_configs:\n",
-    "    print('FYI: train_data_config')\n",
-    "    print('----------------------')\n",
-    "    for cfg in train_data_config:\n",
-    "        print(cfg)\n",
-    "\n",
-    "    print('\\nFYI: experiment_params')\n",
-    "    print('----------------------')\n",
-    "    print(experiment_params)\n",
-    "else:\n",
-    "    print('You opted out of having all params printed... swiftly moving on... ;)')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Wanna trade speed for model quality? (1/2)\n",
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> If you just want to get an idea of the process of training <nobr>Micro$\\mathbb{S}$plit</nobr> and you do not intend to get best-possible results, feel invited to crop down on the training data to be used further down. <i><b>Do not do this</b> if you intend to train a competitive model!!!</i>\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# If True, training and validation data will be reduced to only \n",
-    "# consisting of 2 and 1 frames, respectively.\n",
-    "reduce_data = True\n",
-    "\n",
-    "if reduce_data:\n",
-    "    print(\"Using REDUCED training and validation data for quick'n'dirty testing!\")\n",
-    "    train_dset.reduce_data([0,1])\n",
-    "    val_dset.reduce_data([0])\n",
-    "else:\n",
-    "    print('Using the full set of training and validation data!')\n",
-    "print(f'(This are {train_dset.get_num_frames()} and {val_dset.get_num_frames()} frames, respectively.)') "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Final step: create Dataloaders for network training"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "train_dloader = DataLoader(\n",
-    "    train_dset,\n",
-    "    batch_size=experiment_params[\"batch_size\"],\n",
-    "    num_workers=experiment_params[\"num_workers\"],\n",
-    "    shuffle=True,\n",
-    ")\n",
-    "val_dloader = DataLoader(\n",
-    "    val_dset,\n",
-    "    batch_size=experiment_params[\"batch_size\"],\n",
-    "    num_workers=experiment_params[\"num_workers\"],\n",
-    "    shuffle=False,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.2:** Prepare <nobr>Micro$\\mathbb{S}$plit</nobr> Training\n",
-    "Next, we create all the configs for the upcoming network training run. These lines are not very intuitive and if you don't intend to dive really deep into CAREamics and the internals of <nobr>Micro$\\mathbb{S}$plit</nobr>, you might just execute these cells and move on."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# making our data_stas known to the experiment we prepare\n",
-    "experiment_params[\"data_stats\"] = data_stats\n",
-    "\n",
-    "# setting up training losses and model config (using default parameters)\n",
-    "loss_config = get_loss_config(**experiment_params)\n",
-    "model_config = get_model_config(**experiment_params)\n",
-    "gaussian_lik_config, noise_model_config, nm_lik_config = get_likelihood_config(\n",
-    "    **experiment_params\n",
-    ")\n",
-    "training_config = get_training_config(**experiment_params)\n",
-    "\n",
-    "# setting up learning rate scheduler and optimizer (using default parameters)\n",
-    "lr_scheduler_config = get_lr_scheduler_config(**experiment_params)\n",
-    "optimizer_config = get_optimizer_config(**experiment_params)\n",
-    "\n",
-    "# finally, assemble the full set of experiment configurations...\n",
-    "experiment_config = create_algorithm_config(\n",
-    "    algorithm=experiment_params[\"algorithm\"],\n",
-    "    loss_config=loss_config,\n",
-    "    model_config=model_config,\n",
-    "    gaussian_lik_config=gaussian_lik_config,\n",
-    "    nm_config=noise_model_config,\n",
-    "    nm_lik_config=nm_lik_config,\n",
-    "    lr_scheduler_config=lr_scheduler_config,\n",
-    "    optimizer_config=optimizer_config,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Wanna trade speed for model quality? (2/2)\n",
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> Similar to above, if you simply want to go over this notebook quickly and you don't care about training a competitive model, set <i>`reduce_training_epochs=True`</i> in the cell below. \n",
-    "\n",
-    "Note that if <i> reduce_training_epochs </i> is set to <i>False </i>, the default number of epochs is 400. However, early stopping will be invoked when the loss is no longer decreasing, so the actual number of epochs trained will most likely be less than 400.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reduce_training_epochs = True\n",
-    "\n",
-    "# if True, train for only 10 epochs (quick'n'dirty testing mode)\n",
-    "if reduce_training_epochs:\n",
-    "    training_config.num_epochs = 10\n",
-    "\n",
-    "print(f'Will train for {training_config.num_epochs} epochs!')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Initialize the <nobr>Micro$\\mathbb{S}$plit</nobr> model to be trained.."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model = VAEModule(algorithm_config=experiment_config)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### *Load checkpoint (optional and for you to implement)*\n",
-    "\n",
-    "<div class=\"alert alert-block alert-success\">\n",
-    "<b>Note:</b> If you would like to continue a previous training run or finetune a compatible pre-trained model, here would be a good place. You will need to figure out how to implement this for your use-case, but to give you a head-start, we left three potentially useful lines of code below.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# from microsplit_reproducibility.notebook_utils.HT_LIF24 import load_pretrained_model\n",
-    "# ckpt_path = load_checkpoint_path(f\"./pretrained_checkpoints/{EXPOSURE_DURATION}/\", best=True)\n",
-    "# load_pretrained_model(model, ckpt_path)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Show some training data for a final check!\n",
-    "***Tip:*** we show you a few samples of the prepared training data. In case you don't like what you see, execute the cell again and other randomly chosen patches will be shown!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_input_patches_3d(dataset=train_dset, num_channels=2, num_samples=3, patch_size=128)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.3:** Train the prepared model!\n",
-    "***Note:*** if this takes too long, there were to places above where we gave you options to *(i)* reduce the amount of training data, and *(ii)* chose to train for fewer epochs. Revisit your choices if you want to!\n",
-    "\n",
-    "***Note:*** Depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> above.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# create a CAREamics 'Trainer'\n",
-    "trainer = Trainer(\n",
-    "    max_epochs=training_config.num_epochs,\n",
-    "    # NOTE: if you are on a mac swap the accelerator to \"mps\"\n",
-    "    # accelerator=“mps”,\n",
-    "    accelerator=\"gpu\",\n",
-    "    enable_progress_bar=True,\n",
-    "    callbacks=get_callbacks(f\"./checkpoints/\"),\n",
-    "    precision=training_config.precision,\n",
-    "    gradient_clip_val=training_config.gradient_clip_val,\n",
-    "    gradient_clip_algorithm=training_config.gradient_clip_algorithm,\n",
-    ")\n",
-    "# start the training - yay!\n",
-    "trainer.fit(\n",
-    "    model=model,\n",
-    "    train_dataloaders=train_dloader,\n",
-    "    val_dataloaders=val_dloader,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Show training loss curves...\n",
-    "Below, we plot for each epoch of your training run the *(i)* training reconstruction loss, *(ii)* training KL divergence loss, *(iii)* validation reconstruction loss, and *(iv)* validation PSNR. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pandas import read_csv\n",
-    "from microsplit_reproducibility.notebook_utils.HT_LIF24 import find_recent_metrics, plot_metrics\n",
-    "df = read_csv(find_recent_metrics())\n",
-    "plot_metrics(df)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.4:** Predict and visualize results for validation data..."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "from microsplit_reproducibility.notebook_utils.HT_H24 import (\n",
-    "    get_unnormalized_predictions,\n",
-    "    get_target,\n",
-    "    get_input,\n",
-    ")\n",
-    "\n",
-    "stitched_predictions, _, _ = get_unnormalized_predictions(\n",
-    "    model,\n",
-    "    val_dset,\n",
-    "    mmse_count=experiment_params[\"mmse_count\"],\n",
-    "    num_workers=0,\n",
-    "    batch_size=8,\n",
-    ")\n",
-    "tar = get_target(val_dset)\n",
-    "inp = get_input(val_dset)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Overview: visualize predictions on validation data..."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from microsplit_reproducibility.notebook_utils.HT_H24 import full_frame_evaluation\n",
-    "frame_idx = 0\n",
-    "assert frame_idx < len(stitched_predictions), f\"Frame index {frame_idx} out of bounds\"\n",
-    "full_frame_evaluation(stitched_predictions[frame_idx], tar[frame_idx])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Detailed view on some (foreground) locations...\n",
-    "Below, we show few random foreground locations and the corresponding <nobr>Micro$\\mathbb{S}$plit</nobr> predictions.\n",
-    "\n",
-    "As before, also here you can execute the cell multiple times and different randomly chosen locations will be plotted."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "from microsplit_reproducibility.utils.utils import clean_ax\n",
-    "from microsplit_reproducibility.notebook_utils.HT_H24 import pick_random_patches_with_content\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "img_sz = 64\n",
-    "rand_locations = pick_random_patches_with_content(tar, img_sz)\n",
-    "\n",
-    "h_start = rand_locations[2, 1] #np.random.randint(stitched_predictions.shape[1] - img_sz)\n",
-    "w_start = rand_locations[2, 2] #np.random.randint(stitched_predictions.shape[2] - img_sz)\n",
-    "\n",
-    "ncols = 5\n",
-    "nrows = min(len(rand_locations), 5)\n",
-    "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 3, nrows * 3))\n",
-    "\n",
-    "for i, (z_idx, h_start, w_start) in enumerate(rand_locations[:nrows]):\n",
-    "    ax[i, 0].imshow(inp[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, 0])\n",
-    "    for j in range(ncols//2):\n",
-    "        vmin = stitched_predictions[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j].min()\n",
-    "        vmax = stitched_predictions[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j].max()\n",
-    "        ax[i, 2*j+1].imshow(tar[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j], vmin=vmin, vmax=vmax)\n",
-    "        ax[i, 2*j+2].imshow(stitched_predictions[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j], vmin=vmin, vmax=vmax)\n",
-    "\n",
-    "ax[0,0].set_title('Primary Input')\n",
-    "for i in range(2):\n",
-    "    ax[0, 2*i+1].set_title(f'Target Channel {i+1}')\n",
-    "    ax[0, 2*i+2].set_title(f'Predicted Channel {i+1}')\n",
-    "\n",
-    "# reduce the spacing between the subplots\n",
-    "plt.subplots_adjust(wspace=0.03, hspace=0.03)\n",
-    "clean_ax(ax)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## *Optional:* manual inspection of the predictions\n",
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b> Task:</b> Set <i>y_start</i>, <i>x_start</i>, and <i>crop_size</i> to inspect the predictions at a  location of your choice.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "y_start = 100  #np.random.randint(stitched_predictions.shape[1] - crop_size)\n",
-    "x_start = 100 #np.random.randint(stitched_predictions.shape[2] - crop_size)\n",
-    "z_idx = 0\n",
-    "\n",
-    "crop_size = 128\n",
-    "\n",
-    "ncols = 3\n",
-    "nrows = 2\n",
-    "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 5, nrows * 5))\n",
-    "ax[0,0].imshow(inp[0, z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, 0])\n",
-    "ax[1,0].imshow(inp[0, z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, 1])\n",
-    "\n",
-    "for i in range(ncols -1):\n",
-    "    vmin = stitched_predictions[0, z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i].min()\n",
-    "    vmax = stitched_predictions[0, z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i].max()\n",
-    "    ax[0,i+1].imshow(tar[0,z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i], vmin=vmin, vmax=vmax)\n",
-    "    ax[1,i+1].imshow(stitched_predictions[0, z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i], vmin=vmin, vmax=vmax)\n",
-    "\n",
-    "# disable the axis for ax[1,0]\n",
-    "ax[1,0].axis('off')\n",
-    "ax[0,0].set_title(\"Input\")\n",
-    "ax[0,1].set_title(\"Channel 1\")\n",
-    "ax[0,2].set_title(\"Channel 2\")\n",
-    "# set y labels on the right for ax[0,2]\n",
-    "ax[0,2].yaxis.set_label_position(\"right\")\n",
-    "ax[0,2].set_ylabel(\"Target\")\n",
-    "\n",
-    "ax[1,2].yaxis.set_label_position(\"right\")\n",
-    "ax[1,2].set_ylabel(\"Predicted\")\n",
-    "\n",
-    "print('Here the crop you selected:')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# ***Optional Step 1.4:*** Posterior Sampling\n",
-    "For a given input patch, <nobr>Micro$\\mathbb{S}$plit</nobr> can generate multiple outputs. This is possible because <nobr>Micro$\\mathbb{S}$plit</nobr> is learning a full posterior of possible solutions, which is a quite powerful feature!\n",
-    "\n",
-    "As we elaborate in the <nobr>Micro$\\mathbb{S}$plit</nobr> paper and also later in the calibration notebook `03_calibration.ipynb`, this allows users to visually judge and even quantify the (data) uncertainty in the predictions their trained model makes.\n",
-    "\n",
-    "Below, we show two posterior samples and how much they differ for a few random foreground locations. Re-run the cell to see different randomly choosen locations and corresponding posterior samples."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from microsplit_reproducibility.notebook_utils.HT_H24 import show_sampling\n",
-    "imgsz = 3\n",
-    "ncols = 6\n",
-    "examplecount = 3\n",
-    "_,ax = plt.subplots(figsize=(imgsz*ncols, imgsz*2*examplecount), ncols=ncols, nrows=2*examplecount)\n",
-    "\n",
-    "show_sampling(val_dset, model, ax=ax[:2])\n",
-    "show_sampling(val_dset, model, ax=ax[2:4])\n",
-    "show_sampling(val_dset, model, ax=ax[4:6])\n",
-    "plt.tight_layout()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### You are done here! 👍 Congratulations! 🎉"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "careamics",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.14"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 4
 }

--- a/examples/3D/custom_dataset/01_train.ipynb
+++ b/examples/3D/custom_dataset/01_train.ipynb
@@ -1,748 +1,766 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1:** Training a <nobr>Micro$\\mathbb{S}$plit</nobr> Model"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1:** Training a <nobr>Micro$\\mathbb{S}$plit</nobr> Model"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Introduction - what does this notebook do?"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b>Note:</b> Despite network training arguably being the most important step, the execution of this notebook is optional. If you do not run this notebook, in Step 2 (prediction) we offer you to use pretrained model checkpoints. Like in any respected cooking show: \"we have already prepared someting before the show\"... 😉\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Below, we will train a <nobr>Micro$\\mathbb{S}$plit</nobr> network for unmixing two or more superimposed channels for a custom 3D dataset you provide. \n",
+        "\n",
+        "You should organize you dataset as follows:\n",
+        "- Create a `data` directory\n",
+        "- Create subdirectories `channel_1`, `channel_2`, etc, containing the channels you would like to unmix\n",
+        "- Make sure that the images have the same spatial size and each image has only 1 channel\n",
+        "\n",
+        "Your data directory should look like this:\n",
+        "```\n",
+        "your_data_path/\n",
+        "└── data\n",
+        "    ├── channel_1\n",
+        "    │   ├── image1.tiff\n",
+        "    │   ├── image2.tiff\n",
+        "    │   └── image3.tiff\n",
+        "    └── channel_2\n",
+        "    │   ├── image1.tiff\n",
+        "    │   ├── image2.tiff\n",
+        "    │   └── image3.tiff\n",
+        "    └── channel_n\n",
+        "    │   ├── image1.tiff\n",
+        "    │   ├── image2.tiff\n",
+        "    │   └── image3.tiff\n",
+        "```\n",
+        "\n",
+        "**NOTE**: below you will need to specify the `DATA_PATH` if you are using custom data. For the example above, it would be `DATA_PATH = \"your_data_path/data\"`.\n",
+        "\n",
+        "The mixed image used for splitting will be obtained artificially by a convex combination of the target channels.\n",
+        "\n",
+        "Let's begin!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Background: what is <nobr>Micro$\\mathbb{S}$plit</nobr> training all about?\n",
+        "Training is done in a supervised way. For every input patch, we have the corresponding target patches using which we train our MicroSplit. \n",
+        "Besides the primary input patch, we also feed LC inputs to MicroSplit. We introduced LC inputs in [μSplit: efficient image decomposition for microscopy data](https://openaccess.thecvf.com/content/ICCV2023/papers/Ashesh_uSplit_Image_Decomposition_for_Fluorescence_Microscopy_ICCV_2023_paper.pdf), which enabled the network to understand the global spatial context around the input patch.\n",
+        "\n",
+        "To enable unsupervised denoising, we integrated the KL loss formulation and Noise models from our previous work [denoiSplit: a method for joint microscopy image splitting and unsupervised denoising](https://eccv.ecva.net/virtual/2024/poster/2538). \n",
+        "\n",
+        "The loss function for MicroSplit is a weighted average of denoiSplit loss and μSplit loss. For both denoiSplit and μSplit, their loss expression have two terms: KL divergence loss and likelihood loss. For more details, please refer to the respective papers."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Let's do it, let's train a <nobr>Micro$\\mathbb{S}$plit</nobr> Model!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**You are new to Jupyter notebooks?** Don't worry, if you take the time to read all our explanations, we will guide you through them and you will understand a lot. Still, you will likely end up less frustrated, if you do not even start with the ambition to interpret the purpose of every line of code.\n",
+        "Let's start with a nice example, the imports to enable the remainder of this notebook. Ignore it (unless you know what you are doing) and just click **⇧*Shift* + ⏎*Enter*** to execute this (and all other) code cells. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# importing all the things we need further down\n",
+        "import platform\n",
+        "import pooch\n",
+        "from pathlib import Path\n",
+        "from pytorch_lightning import Trainer\n",
+        "from torch.utils.data import DataLoader\n",
+        "from careamics.lightning import VAEModule\n",
+        "\n",
+        "from microsplit_reproducibility.configs.factory import (\n",
+        "    create_algorithm_config,\n",
+        "    get_likelihood_config,\n",
+        "    get_loss_config,\n",
+        "    get_model_config,\n",
+        "    get_optimizer_config,\n",
+        "    get_training_config,\n",
+        "    get_lr_scheduler_config,\n",
+        ")\n",
+        "from microsplit_reproducibility.utils.callbacks import get_callbacks\n",
+        "from microsplit_reproducibility.utils.io import load_checkpoint, load_checkpoint_path\n",
+        "from microsplit_reproducibility.datasets import create_train_val_datasets\n",
+        "from microsplit_reproducibility.utils.utils import (\n",
+        "    plot_training_metrics,\n",
+        "    plot_input_patches_3d,\n",
+        "    plot_training_outputs,\n",
+        ")\n",
+        "\n",
+        "# Dataset specific imports...\n",
+        "from microsplit_reproducibility.configs.parameters.custom_dataset_3D import get_microsplit_parameters\n",
+        "from microsplit_reproducibility.configs.data.custom_dataset_3D import get_data_configs\n",
+        "from microsplit_reproducibility.datasets.custom_dataset_3D import get_train_val_data"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.1:** Data Preparation"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Load example data"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "DATA = pooch.create(\n",
+        "    path=f\"./\",\n",
+        "    base_url=f\"https://download.fht.org/jug/msplit/custom3D\",\n",
+        "    registry={f\"custom_3Ddata_example.zip\": None},\n",
+        ")\n",
+        "for fname in DATA.registry:\n",
+        "    DATA.fetch(fname, processor=pooch.Unzip(), progressbar=True)\n",
+        "\n",
+        "# DATA_PATH = DATA.abspath / (DATA.registry_files[0] + \".unzip/data/\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### OR set the path to your own data\n",
+        "Important: the path should end with `data/`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# DATA_PATH = Path(\"your_data_path/data\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Setup the path to the noise models\n",
+        "This is the path to the noise models that you trained in the notebook **00_noisemodels.ipynb**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "NM_PATH = Path(\"./noise_models/\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Next, we load the image data to be processed\n",
+        "\n",
+        "Note that depending on the amount of GPU memory you have available, you might want to adjust the `BATCH_SIZE`. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter.\n",
+        "\n",
+        "Number of `EPOCHS` is set to 3, which usually allows to see decent results for 3D datasets. However, for getting optimal performance you can increase it to 10.\n",
+        "\n",
+        "You also need to specify:\n",
+        "- the `NUM_CHANNELS` parameter, which controls the number of channels in the input data depending on how many channels you want to split.\n",
+        "- the `NUM_Z_SLICES` parameter, which tells the number of slices in your Z-stack. **NOTE: we expect all your input images to have the same number of Z-slices!!!**\n",
+        "\n",
+        "Finally, ensure that the `PATCH_SIZE` parameter (i.e., the patch size in (`Z`, `Y`, `X`) you want to use to train the model) is properly set given the size of your data and of you GPU."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "NUM_CHANNELS = 2\n",
+        "\"\"\"The number of channels considered for the splitting task.\"\"\"\n",
+        "NUM_Z_SLICES = 20\n",
+        "\"\"\"The number of z slices in the input data.\"\"\"\n",
+        "BATCH_SIZE = 32\n",
+        "\"\"\"The batch size for training.\"\"\"\n",
+        "PATCH_SIZE = (8, 64, 64)\n",
+        "\"\"\"The size of the patches fed to the network for training in (Z, Y, X).\"\"\"\n",
+        "EPOCHS = 3\n",
+        "\"\"\"The number of epochs to train the network.\"\"\"\n",
+        "\n",
+        "assert len(PATCH_SIZE) == 3, \"Patch size must be a tuple of length 3 (Z, Y, X) since we are using 3D data.\"\n",
+        "assert PATCH_SIZE[0] <= NUM_Z_SLICES, \"Patch size in Z dimension must be smaller than or equal to the number of z slices in the input data.\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# setting up train, validation, and test data configs\n",
+        "train_data_config, val_data_config, test_data_config = get_data_configs(\n",
+        "    image_size=PATCH_SIZE,\n",
+        "    num_channels=NUM_CHANNELS,\n",
+        "    num_z_slices=NUM_Z_SLICES,\n",
+        ")\n",
+        "\n",
+        "# setting up MicroSplit parametrization\n",
+        "experiment_params = get_microsplit_parameters(\n",
+        "    algorithm=\"denoisplit\",\n",
+        "    img_size=PATCH_SIZE,\n",
+        "    batch_size=BATCH_SIZE,\n",
+        "    num_epochs=EPOCHS,\n",
+        "    multiscale_count=1,\n",
+        "    noise_model_path=NM_PATH,\n",
+        "    target_channels=NUM_CHANNELS,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Configure `num_workers`\n",
+        "In Windows and MacOS, setting `num_workers > 0` for dataloaders would cause out-of-memory issue and might crash the system."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def get_num_workers():\n",
+        "    \"\"\"Utility function to set num_workers based on OS.\"\"\"\n",
+        "    if platform.system() == \"Windows\" or platform.system() == \"Darwin\":\n",
+        "        return 0\n",
+        "    else:\n",
+        "        return 3  # or any other number suitable for your system\n",
+        "\n",
+        "experiment_params[\"num_workers\"] = get_num_workers()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# start the download of required files\n",
+        "train_dset, val_dset, _, data_stats = create_train_val_datasets(\n",
+        "    datapath=DATA_PATH,\n",
+        "    train_config=train_data_config,\n",
+        "    val_config=val_data_config,\n",
+        "    test_config=val_data_config,\n",
+        "    load_data_func=get_train_val_data,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "***Optional:*** inspect data configurations and <nobr>Micro$\\mathbb{S}$plit</nobr> config"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "do_show_configs = True\n",
+        "\n",
+        "if do_show_configs:\n",
+        "    print('FYI: train_data_config')\n",
+        "    print('----------------------')\n",
+        "    for cfg in train_data_config:\n",
+        "        print(cfg)\n",
+        "\n",
+        "    print('\\nFYI: experiment_params')\n",
+        "    print('----------------------')\n",
+        "    print(experiment_params)\n",
+        "else:\n",
+        "    print('You opted out of having all params printed... swiftly moving on... ;)')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Wanna trade speed for model quality?\n",
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b>Note:</b> If you just want to get an idea of the process of training <nobr>Micro$\\mathbb{S}$plit</nobr> and you do not intend to get best-possible results, feel invited to crop down on the training data to be used further down. <i><b>Do not do this</b> if you intend to train a competitive model!!!</i>\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# If True, training and validation data will be reduced to only \n",
+        "# consisting of 2 and 1 frames, respectively.\n",
+        "reduce_data = True\n",
+        "\n",
+        "if reduce_data:\n",
+        "    print(\"Using REDUCED training and validation data for quick'n'dirty testing!\")\n",
+        "    train_dset.reduce_data([0, 1])\n",
+        "    val_dset.reduce_data([0])\n",
+        "else:\n",
+        "    print('Using the full set of training and validation data!')\n",
+        "print(f'(This are {train_dset.get_num_frames()} and {val_dset.get_num_frames()} frames, respectively.)') "
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Final step: create Dataloaders for network training"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "train_dloader = DataLoader(\n",
+        "    train_dset,\n",
+        "    batch_size=experiment_params[\"batch_size\"],\n",
+        "    num_workers=experiment_params[\"num_workers\"],\n",
+        "    shuffle=True,\n",
+        ")\n",
+        "val_dloader = DataLoader(\n",
+        "    val_dset,\n",
+        "    batch_size=experiment_params[\"batch_size\"],\n",
+        "    num_workers=experiment_params[\"num_workers\"],\n",
+        "    shuffle=False,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.2:** Prepare <nobr>Micro$\\mathbb{S}$plit</nobr> Training\n",
+        "Next, we create all the configs for the upcoming network training run. These lines are not very intuitive and if you don't intend to dive really deep into CAREamics and the internals of <nobr>Micro$\\mathbb{S}$plit</nobr>, you might just execute these cells and move on."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# making our data_stas known to the experiment we prepare\n",
+        "experiment_params[\"data_stats\"] = data_stats\n",
+        "\n",
+        "# setting up training losses and model config (using default parameters)\n",
+        "loss_config = get_loss_config(**experiment_params)\n",
+        "model_config = get_model_config(**experiment_params)\n",
+        "gaussian_lik_config, noise_model_config, nm_lik_config = get_likelihood_config(\n",
+        "    **experiment_params\n",
+        ")\n",
+        "training_config = get_training_config(**experiment_params)\n",
+        "\n",
+        "# setting up learning rate scheduler and optimizer (using default parameters)\n",
+        "lr_scheduler_config = get_lr_scheduler_config(**experiment_params)\n",
+        "optimizer_config = get_optimizer_config(**experiment_params)\n",
+        "\n",
+        "# finally, assemble the full set of experiment configurations...\n",
+        "experiment_config = create_algorithm_config(\n",
+        "    algorithm=experiment_params[\"algorithm\"],\n",
+        "    loss_config=loss_config,\n",
+        "    model_config=model_config,\n",
+        "    gaussian_lik_config=gaussian_lik_config,\n",
+        "    nm_config=noise_model_config,\n",
+        "    nm_lik_config=nm_lik_config,\n",
+        "    lr_scheduler_config=lr_scheduler_config,\n",
+        "    optimizer_config=optimizer_config,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Initialize the <nobr>Micro$\\mathbb{S}$plit</nobr> model to be trained.."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "model = VAEModule(algorithm_config=experiment_config)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### *Load checkpoint (optional and for you to implement)*\n",
+        "\n",
+        "<div class=\"alert alert-block alert-success\">\n",
+        "<b>Note:</b> If you would like to continue a previous training run or finetune a compatible pre-trained model, here would be a good place. You will need to figure out how to implement this for your use-case, but to give you a head-start, we left three potentially useful lines of code below.\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# from microsplit_reproducibility.notebook_utils.custom_dataset_3D import load_pretrained_model\n",
+        "\n",
+        "# ckpt_path = load_checkpoint_path(f\"./checkpoints/\", best=True)\n",
+        "# load_pretrained_model(model, ckpt_path)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Show some training data for a final check!\n",
+        "***Tip:*** we show you a few samples of the prepared training data. In case you don't like what you see, execute the cell again and other randomly chosen patches will be shown!"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "plot_input_patches_3d(dataset=train_dset, num_channels=NUM_CHANNELS, num_samples=3, patch_size=128)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.3:** Train the prepared model!\n",
+        "***Note:*** if this takes too long, there were to places above where we gave you options to *(i)* reduce the amount of training data, and *(ii)* chose to train for fewer epochs. Revisit your choices if you want to!\n",
+        "\n",
+        "***Note:*** Depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> above.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### If you're not using MPS as your accelerator, ingore next cell"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# If you encounter float \"Cannot convert a MPS Tensor to float64\" error, run this cell\n",
+        "from microsplit_reproducibility.utils.utils import cast_model_floats\n",
+        "cast_model_floats(model)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# create a CAREamics 'Trainer'\n",
+        "trainer = Trainer(\n",
+        "    max_epochs=training_config.num_epochs,\n",
+        "    # NOTE: if you are on a mac swap the accelerator to \"mps\"\n",
+        "    # accelerator=“mps”,\n",
+        "    accelerator=\"gpu\",\n",
+        "    enable_progress_bar=True,\n",
+        "    callbacks=get_callbacks(f\"./checkpoints/\"),\n",
+        "    precision=training_config.precision,\n",
+        "    gradient_clip_val=training_config.gradient_clip_val,\n",
+        "    gradient_clip_algorithm=training_config.gradient_clip_algorithm,\n",
+        ")\n",
+        "\n",
+        "# start the training - yay!\n",
+        "trainer.fit(\n",
+        "    model=model,\n",
+        "    train_dataloaders=train_dloader,\n",
+        "    val_dataloaders=val_dloader,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Show training loss curves...\n",
+        "Below, we plot for each epoch of your training run the *(i)* training reconstruction loss, *(ii)* training KL divergence loss, *(iii)* validation reconstruction loss, and *(iv)* validation PSNR. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pandas import read_csv\n",
+        "from microsplit_reproducibility.notebook_utils.HT_LIF24 import find_recent_metrics, plot_metrics\n",
+        "\n",
+        "df = read_csv(find_recent_metrics())\n",
+        "plot_metrics(df)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# **Step 1.4:** Predict and visualize results for validation data..."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "scrolled": true
+      },
+      "outputs": [],
+      "source": [
+        "from microsplit_reproducibility.notebook_utils.custom_dataset_3D import (\n",
+        "    get_unnormalized_predictions, get_target, get_input\n",
+        ")\n",
+        "\n",
+        "stitched_predictions, _, _ = get_unnormalized_predictions(\n",
+        "    model,\n",
+        "    val_dset,\n",
+        "    data_key=val_dset._fpath.name,\n",
+        "    mmse_count=experiment_params['mmse_count'],\n",
+        "    num_workers=0,\n",
+        "    batch_size=8\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "tar = get_target(val_dset)\n",
+        "inp = get_input(val_dset).sum(axis=-1)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Overview: visualize predictions on validation data..."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from microsplit_reproducibility.notebook_utils.custom_dataset_3D import full_frame_evaluation\n",
+        "\n",
+        "frame_idx = 0\n",
+        "assert frame_idx < len(stitched_predictions), f\"Frame index {frame_idx} out of bounds\"\n",
+        "\n",
+        "full_frame_evaluation(stitched_predictions[frame_idx], tar[frame_idx], inp[frame_idx])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Detailed view on some (foreground) locations...\n",
+        "Below, we show few random foreground locations and the corresponding <nobr>Micro$\\mathbb{S}$plit</nobr> predictions.\n",
+        "\n",
+        "As before, also here you can execute the cell multiple times and different randomly chosen locations will be plotted."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from microsplit_reproducibility.utils.utils import clean_ax\n",
+        "from microsplit_reproducibility.notebook_utils.custom_dataset_3D import pick_random_patches_with_content\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "img_sz = 128\n",
+        "rand_locations = pick_random_patches_with_content(tar, 128)\n",
+        "h_start = rand_locations[2, 1] #np.random.randint(stitched_predictions.shape[1] - img_sz)\n",
+        "w_start = rand_locations[2, 2] #np.random.randint(stitched_predictions.shape[2] - img_sz)\n",
+        "\n",
+        "ncols = 2*NUM_CHANNELS + 1\n",
+        "nrows = min(len(rand_locations), 5)\n",
+        "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 3, nrows * 3))\n",
+        "\n",
+        "for i, (z_idx, h_start, w_start) in enumerate(rand_locations[:nrows]):\n",
+        "    ax[i, 0].imshow(inp[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz])\n",
+        "    for j in range(ncols//2):\n",
+        "        vmin = stitched_predictions[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j].min()\n",
+        "        vmax = stitched_predictions[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j].max()\n",
+        "        ax[i, 2*j+1].imshow(tar[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j], vmin=vmin, vmax=vmax)\n",
+        "        ax[i, 2*j+2].imshow(stitched_predictions[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j], vmin=vmin, vmax=vmax)\n",
+        "\n",
+        "ax[0,0].set_title('Primary Input')\n",
+        "for i in range(NUM_CHANNELS):\n",
+        "    ax[0, 2*i+1].set_title(f'Target Channel {i+1}')\n",
+        "    ax[0, 2*i+2].set_title(f'Predicted Channel {i+1}')\n",
+        "\n",
+        "# reduce the spacing between the subplots\n",
+        "plt.subplots_adjust(wspace=0.03, hspace=0.03)\n",
+        "clean_ax(ax)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## *Optional:* manual inspection of the predictions\n",
+        "<div class=\"alert alert-block alert-info\">\n",
+        "<b> Task:</b> Set <i>y_start</i>, <i>x_start</i>, and <i>crop_size</i> to inspect the predictions at a  location of your choice.\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "y_start = 600  #np.random.randint(stitched_predictions.shape[1] - crop_size)\n",
+        "x_start = 1150 #np.random.randint(stitched_predictions.shape[2] - crop_size)\n",
+        "z_idx = 0\n",
+        "crop_size = 128\n",
+        "\n",
+        "ncols = NUM_CHANNELS + 1\n",
+        "nrows = 2\n",
+        "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 5, nrows * 5))\n",
+        "ax[0,0].imshow(inp[0, z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size])\n",
+        "for i in range(ncols -1):\n",
+        "    vmin = stitched_predictions[0,z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i].min()\n",
+        "    vmax = stitched_predictions[0,z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i].max()\n",
+        "    ax[0,i+1].imshow(tar[0,z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i], vmin=vmin, vmax=vmax)\n",
+        "    ax[1,i+1].imshow(stitched_predictions[0, z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i], vmin=vmin, vmax=vmax)\n",
+        "\n",
+        "# disable the axis for ax[1,0]\n",
+        "ax[1,0].axis('off')\n",
+        "ax[0,0].set_title(\"Input\")\n",
+        "ax[0,1].set_title(\"Channel 1\")\n",
+        "ax[0,2].set_title(\"Channel 2\")\n",
+        "# set y labels on the right for ax[0,2]\n",
+        "ax[0,2].yaxis.set_label_position(\"right\")\n",
+        "ax[0,2].set_ylabel(\"Target\")\n",
+        "\n",
+        "ax[1,2].yaxis.set_label_position(\"right\")\n",
+        "ax[1,2].set_ylabel(\"Predicted\")\n",
+        "\n",
+        "print('Here the crop you selected:')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# ***Optional Step 1.4:*** Posterior Sampling\n",
+        "For a given input patch, <nobr>Micro$\\mathbb{S}$plit</nobr> can generate multiple outputs. This is possible because <nobr>Micro$\\mathbb{S}$plit</nobr> is learning a full posterior of possible solutions, which is a quite powerful feature!\n",
+        "\n",
+        "As we elaborate in the <nobr>Micro$\\mathbb{S}$plit</nobr> paper and also later in the calibration notebook `03_calibration.ipynb`, this allows users to visually judge and even quantify the (data) uncertainty in the predictions their trained model makes.\n",
+        "\n",
+        "Below, we show two posterior samples and how much they differ for a few random foreground locations. Re-run the cell to see different randomly choosen locations and corresponding posterior samples."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from microsplit_reproducibility.notebook_utils.custom_dataset_3D import show_sampling\n",
+        "imgsz = 3\n",
+        "ncols = 6\n",
+        "examplecount = 3\n",
+        "_,ax = plt.subplots(figsize=(imgsz*ncols, imgsz*2*examplecount), ncols=ncols, nrows=2*examplecount)\n",
+        "\n",
+        "show_sampling(val_dset, model, ax=ax[:2])\n",
+        "show_sampling(val_dset, model, ax=ax[2:4])\n",
+        "show_sampling(val_dset, model, ax=ax[4:6])\n",
+        "plt.tight_layout()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### You are done here! 👍 Congratulations! 🎉"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "careamics",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.14"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Introduction - what does this notebook do?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> Despite network training arguably being the most important step, the execution of this notebook is optional. If you do not run this notebook, in Step 2 (prediction) we offer you to use pretrained model checkpoints. Like in any respected cooking show: \"we have already prepared someting before the show\"... 😉\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Below, we will train a <nobr>Micro$\\mathbb{S}$plit</nobr> network for unmixing two or more superimposed channels for a custom 3D dataset you provide. \n",
-    "\n",
-    "You should organize you dataset as follows:\n",
-    "- Create a `data` directory\n",
-    "- Create subdirectories `channel_1`, `channel_2`, etc, containing the channels you would like to unmix\n",
-    "- Make sure that the images have the same spatial size and each image has only 1 channel\n",
-    "\n",
-    "Your data directory should look like this:\n",
-    "```\n",
-    "your_data_path/\n",
-    "└── data\n",
-    "    ├── channel_1\n",
-    "    │   ├── image1.tiff\n",
-    "    │   ├── image2.tiff\n",
-    "    │   └── image3.tiff\n",
-    "    └── channel_2\n",
-    "    │   ├── image1.tiff\n",
-    "    │   ├── image2.tiff\n",
-    "    │   └── image3.tiff\n",
-    "    └── channel_n\n",
-    "    │   ├── image1.tiff\n",
-    "    │   ├── image2.tiff\n",
-    "    │   └── image3.tiff\n",
-    "```\n",
-    "\n",
-    "**NOTE**: below you will need to specify the `DATA_PATH` if you are using custom data. For the example above, it would be `DATA_PATH = \"your_data_path/data\"`.\n",
-    "\n",
-    "The mixed image used for splitting will be obtained artificially by a convex combination of the target channels.\n",
-    "\n",
-    "Let's begin!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Background: what is <nobr>Micro$\\mathbb{S}$plit</nobr> training all about?\n",
-    "Training is done in a supervised way. For every input patch, we have the corresponding target patches using which we train our MicroSplit. \n",
-    "Besides the primary input patch, we also feed LC inputs to MicroSplit. We introduced LC inputs in [μSplit: efficient image decomposition for microscopy data](https://openaccess.thecvf.com/content/ICCV2023/papers/Ashesh_uSplit_Image_Decomposition_for_Fluorescence_Microscopy_ICCV_2023_paper.pdf), which enabled the network to understand the global spatial context around the input patch.\n",
-    "\n",
-    "To enable unsupervised denoising, we integrated the KL loss formulation and Noise models from our previous work [denoiSplit: a method for joint microscopy image splitting and unsupervised denoising](https://eccv.ecva.net/virtual/2024/poster/2538). \n",
-    "\n",
-    "The loss function for MicroSplit is a weighted average of denoiSplit loss and μSplit loss. For both denoiSplit and μSplit, their loss expression have two terms: KL divergence loss and likelihood loss. For more details, please refer to the respective papers."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Let's do it, let's train a <nobr>Micro$\\mathbb{S}$plit</nobr> Model!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**You are new to Jupyter notebooks?** Don't worry, if you take the time to read all our explanations, we will guide you through them and you will understand a lot. Still, you will likely end up less frustrated, if you do not even start with the ambition to interpret the purpose of every line of code.\n",
-    "Let's start with a nice example, the imports to enable the remainder of this notebook. Ignore it (unless you know what you are doing) and just click **⇧*Shift* + ⏎*Enter*** to execute this (and all other) code cells. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# importing all the things we need further down\n",
-    "import platform\n",
-    "import pooch\n",
-    "from pathlib import Path\n",
-    "from pytorch_lightning import Trainer\n",
-    "from torch.utils.data import DataLoader\n",
-    "from careamics.lightning import VAEModule\n",
-    "\n",
-    "from microsplit_reproducibility.configs.factory import (\n",
-    "    create_algorithm_config,\n",
-    "    get_likelihood_config,\n",
-    "    get_loss_config,\n",
-    "    get_model_config,\n",
-    "    get_optimizer_config,\n",
-    "    get_training_config,\n",
-    "    get_lr_scheduler_config,\n",
-    ")\n",
-    "from microsplit_reproducibility.utils.callbacks import get_callbacks\n",
-    "from microsplit_reproducibility.utils.io import load_checkpoint, load_checkpoint_path\n",
-    "from microsplit_reproducibility.datasets import create_train_val_datasets\n",
-    "from microsplit_reproducibility.utils.utils import (\n",
-    "    plot_training_metrics,\n",
-    "    plot_input_patches_3d,\n",
-    "    plot_training_outputs,\n",
-    ")\n",
-    "\n",
-    "# Dataset specific imports...\n",
-    "from microsplit_reproducibility.configs.parameters.custom_dataset_3D import get_microsplit_parameters\n",
-    "from microsplit_reproducibility.configs.data.custom_dataset_3D import get_data_configs\n",
-    "from microsplit_reproducibility.datasets.custom_dataset_3D import get_train_val_data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.1:** Data Preparation"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Load example data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "DATA = pooch.create(\n",
-    "    path=f\"./\",\n",
-    "    base_url=f\"https://download.fht.org/jug/msplit/custom3D\",\n",
-    "    registry={f\"custom_3Ddata_example.zip\": None},\n",
-    ")\n",
-    "for fname in DATA.registry:\n",
-    "    DATA.fetch(fname, processor=pooch.Unzip(), progressbar=True)\n",
-    "\n",
-    "# DATA_PATH = DATA.abspath / (DATA.registry_files[0] + \".unzip/data/\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### OR set the path to your own data\n",
-    "Important: the path should end with `data/`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# DATA_PATH = Path(\"your_data_path/data\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Setup the path to the noise models\n",
-    "This is the path to the noise models that you trained in the notebook **00_noisemodels.ipynb**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "NM_PATH = Path(\"./noise_models/\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Next, we load the image data to be processed\n",
-    "\n",
-    "Note that depending on the amount of GPU memory you have available, you might want to adjust the `BATCH_SIZE`. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter.\n",
-    "\n",
-    "Number of `EPOCHS` is set to 3, which usually allows to see decent results for 3D datasets. However, for getting optimal performance you can increase it to 10.\n",
-    "\n",
-    "You also need to specify:\n",
-    "- the `NUM_CHANNELS` parameter, which controls the number of channels in the input data depending on how many channels you want to split.\n",
-    "- the `NUM_Z_SLICES` parameter, which tells the number of slices in your Z-stack. **NOTE: we expect all your input images to have the same number of Z-slices!!!**\n",
-    "\n",
-    "Finally, ensure that the `PATCH_SIZE` parameter (i.e., the patch size in (`Z`, `Y`, `X`) you want to use to train the model) is properly set given the size of your data and of you GPU."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "NUM_CHANNELS = 2\n",
-    "\"\"\"The number of channels considered for the splitting task.\"\"\"\n",
-    "NUM_Z_SLICES = 20\n",
-    "\"\"\"The number of z slices in the input data.\"\"\"\n",
-    "BATCH_SIZE = 32\n",
-    "\"\"\"The batch size for training.\"\"\"\n",
-    "PATCH_SIZE = (8, 64, 64)\n",
-    "\"\"\"The size of the patches fed to the network for training in (Z, Y, X).\"\"\"\n",
-    "EPOCHS = 3\n",
-    "\"\"\"The number of epochs to train the network.\"\"\"\n",
-    "\n",
-    "assert len(PATCH_SIZE) == 3, \"Patch size must be a tuple of length 3 (Z, Y, X) since we are using 3D data.\"\n",
-    "assert PATCH_SIZE[0] <= NUM_Z_SLICES, \"Patch size in Z dimension must be smaller than or equal to the number of z slices in the input data.\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# setting up train, validation, and test data configs\n",
-    "train_data_config, val_data_config, test_data_config = get_data_configs(\n",
-    "    image_size=PATCH_SIZE,\n",
-    "    num_channels=NUM_CHANNELS,\n",
-    "    num_z_slices=NUM_Z_SLICES,\n",
-    ")\n",
-    "\n",
-    "# setting up MicroSplit parametrization\n",
-    "experiment_params = get_microsplit_parameters(\n",
-    "    algorithm=\"denoisplit\",\n",
-    "    img_size=PATCH_SIZE,\n",
-    "    batch_size=BATCH_SIZE,\n",
-    "    num_epochs=EPOCHS,\n",
-    "    multiscale_count=1,\n",
-    "    noise_model_path=NM_PATH,\n",
-    "    target_channels=NUM_CHANNELS,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Configure `num_workers`\n",
-    "In Windows and MacOS, setting `num_workers > 0` for dataloaders would cause out-of-memory issue and might crash the system."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_num_workers():\n",
-    "    \"\"\"Utility function to set num_workers based on OS.\"\"\"\n",
-    "    if platform.system() == \"Windows\" or platform.system() == \"Darwin\":\n",
-    "        return 0\n",
-    "    else:\n",
-    "        return 3  # or any other number suitable for your system\n",
-    "\n",
-    "experiment_params[\"num_workers\"] = get_num_workers()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# start the download of required files\n",
-    "train_dset, val_dset, _, data_stats = create_train_val_datasets(\n",
-    "    datapath=DATA_PATH,\n",
-    "    train_config=train_data_config,\n",
-    "    val_config=val_data_config,\n",
-    "    test_config=val_data_config,\n",
-    "    load_data_func=get_train_val_data,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "***Optional:*** inspect data configurations and <nobr>Micro$\\mathbb{S}$plit</nobr> config"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "do_show_configs = True\n",
-    "\n",
-    "if do_show_configs:\n",
-    "    print('FYI: train_data_config')\n",
-    "    print('----------------------')\n",
-    "    for cfg in train_data_config:\n",
-    "        print(cfg)\n",
-    "\n",
-    "    print('\\nFYI: experiment_params')\n",
-    "    print('----------------------')\n",
-    "    print(experiment_params)\n",
-    "else:\n",
-    "    print('You opted out of having all params printed... swiftly moving on... ;)')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Wanna trade speed for model quality?\n",
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> If you just want to get an idea of the process of training <nobr>Micro$\\mathbb{S}$plit</nobr> and you do not intend to get best-possible results, feel invited to crop down on the training data to be used further down. <i><b>Do not do this</b> if you intend to train a competitive model!!!</i>\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# If True, training and validation data will be reduced to only \n",
-    "# consisting of 2 and 1 frames, respectively.\n",
-    "reduce_data = True\n",
-    "\n",
-    "if reduce_data:\n",
-    "    print(\"Using REDUCED training and validation data for quick'n'dirty testing!\")\n",
-    "    train_dset.reduce_data([0, 1])\n",
-    "    val_dset.reduce_data([0])\n",
-    "else:\n",
-    "    print('Using the full set of training and validation data!')\n",
-    "print(f'(This are {train_dset.get_num_frames()} and {val_dset.get_num_frames()} frames, respectively.)') "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Final step: create Dataloaders for network training"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "train_dloader = DataLoader(\n",
-    "    train_dset,\n",
-    "    batch_size=experiment_params[\"batch_size\"],\n",
-    "    num_workers=experiment_params[\"num_workers\"],\n",
-    "    shuffle=True,\n",
-    ")\n",
-    "val_dloader = DataLoader(\n",
-    "    val_dset,\n",
-    "    batch_size=experiment_params[\"batch_size\"],\n",
-    "    num_workers=experiment_params[\"num_workers\"],\n",
-    "    shuffle=False,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.2:** Prepare <nobr>Micro$\\mathbb{S}$plit</nobr> Training\n",
-    "Next, we create all the configs for the upcoming network training run. These lines are not very intuitive and if you don't intend to dive really deep into CAREamics and the internals of <nobr>Micro$\\mathbb{S}$plit</nobr>, you might just execute these cells and move on."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# making our data_stas known to the experiment we prepare\n",
-    "experiment_params[\"data_stats\"] = data_stats\n",
-    "\n",
-    "# setting up training losses and model config (using default parameters)\n",
-    "loss_config = get_loss_config(**experiment_params)\n",
-    "model_config = get_model_config(**experiment_params)\n",
-    "gaussian_lik_config, noise_model_config, nm_lik_config = get_likelihood_config(\n",
-    "    **experiment_params\n",
-    ")\n",
-    "training_config = get_training_config(**experiment_params)\n",
-    "\n",
-    "# setting up learning rate scheduler and optimizer (using default parameters)\n",
-    "lr_scheduler_config = get_lr_scheduler_config(**experiment_params)\n",
-    "optimizer_config = get_optimizer_config(**experiment_params)\n",
-    "\n",
-    "# finally, assemble the full set of experiment configurations...\n",
-    "experiment_config = create_algorithm_config(\n",
-    "    algorithm=experiment_params[\"algorithm\"],\n",
-    "    loss_config=loss_config,\n",
-    "    model_config=model_config,\n",
-    "    gaussian_lik_config=gaussian_lik_config,\n",
-    "    nm_config=noise_model_config,\n",
-    "    nm_lik_config=nm_lik_config,\n",
-    "    lr_scheduler_config=lr_scheduler_config,\n",
-    "    optimizer_config=optimizer_config,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Initialize the <nobr>Micro$\\mathbb{S}$plit</nobr> model to be trained.."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model = VAEModule(algorithm_config=experiment_config)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### *Load checkpoint (optional and for you to implement)*\n",
-    "\n",
-    "<div class=\"alert alert-block alert-success\">\n",
-    "<b>Note:</b> If you would like to continue a previous training run or finetune a compatible pre-trained model, here would be a good place. You will need to figure out how to implement this for your use-case, but to give you a head-start, we left three potentially useful lines of code below.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# from microsplit_reproducibility.notebook_utils.custom_dataset_3D import load_pretrained_model\n",
-    "\n",
-    "# ckpt_path = load_checkpoint_path(f\"./checkpoints/\", best=True)\n",
-    "# load_pretrained_model(model, ckpt_path)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Show some training data for a final check!\n",
-    "***Tip:*** we show you a few samples of the prepared training data. In case you don't like what you see, execute the cell again and other randomly chosen patches will be shown!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_input_patches_3d(dataset=train_dset, num_channels=NUM_CHANNELS, num_samples=3, patch_size=128)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.3:** Train the prepared model!\n",
-    "***Note:*** if this takes too long, there were to places above where we gave you options to *(i)* reduce the amount of training data, and *(ii)* chose to train for fewer epochs. Revisit your choices if you want to!\n",
-    "\n",
-    "***Note:*** Depending on the amount of GPU memory you have available, you might want to adjust the batch size. The default is 32, but you can reduce it to 16 if you run out of memory by changing the <i> batch_size </i> parameter in <i> get_microsplit_parameters </i> above.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# create a CAREamics 'Trainer'\n",
-    "trainer = Trainer(\n",
-    "    max_epochs=training_config.num_epochs,\n",
-    "    # NOTE: if you are on a mac swap the accelerator to \"mps\"\n",
-    "    # accelerator=“mps”,\n",
-    "    accelerator=\"gpu\",\n",
-    "    enable_progress_bar=True,\n",
-    "    callbacks=get_callbacks(f\"./checkpoints/\"),\n",
-    "    precision=training_config.precision,\n",
-    "    gradient_clip_val=training_config.gradient_clip_val,\n",
-    "    gradient_clip_algorithm=training_config.gradient_clip_algorithm,\n",
-    ")\n",
-    "\n",
-    "# start the training - yay!\n",
-    "trainer.fit(\n",
-    "    model=model,\n",
-    "    train_dataloaders=train_dloader,\n",
-    "    val_dataloaders=val_dloader,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Show training loss curves...\n",
-    "Below, we plot for each epoch of your training run the *(i)* training reconstruction loss, *(ii)* training KL divergence loss, *(iii)* validation reconstruction loss, and *(iv)* validation PSNR. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pandas import read_csv\n",
-    "from microsplit_reproducibility.notebook_utils.HT_LIF24 import find_recent_metrics, plot_metrics\n",
-    "\n",
-    "df = read_csv(find_recent_metrics())\n",
-    "plot_metrics(df)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# **Step 1.4:** Predict and visualize results for validation data..."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "from microsplit_reproducibility.notebook_utils.custom_dataset_3D import (\n",
-    "    get_unnormalized_predictions, get_target, get_input\n",
-    ")\n",
-    "\n",
-    "stitched_predictions, _, _ = get_unnormalized_predictions(\n",
-    "    model,\n",
-    "    val_dset,\n",
-    "    data_key=val_dset._fpath.name,\n",
-    "    mmse_count=experiment_params['mmse_count'],\n",
-    "    num_workers=0,\n",
-    "    batch_size=8\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tar = get_target(val_dset)\n",
-    "inp = get_input(val_dset).sum(axis=-1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Overview: visualize predictions on validation data..."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from microsplit_reproducibility.notebook_utils.custom_dataset_3D import full_frame_evaluation\n",
-    "\n",
-    "frame_idx = 0\n",
-    "assert frame_idx < len(stitched_predictions), f\"Frame index {frame_idx} out of bounds\"\n",
-    "\n",
-    "full_frame_evaluation(stitched_predictions[frame_idx], tar[frame_idx], inp[frame_idx])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Detailed view on some (foreground) locations...\n",
-    "Below, we show few random foreground locations and the corresponding <nobr>Micro$\\mathbb{S}$plit</nobr> predictions.\n",
-    "\n",
-    "As before, also here you can execute the cell multiple times and different randomly chosen locations will be plotted."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from microsplit_reproducibility.utils.utils import clean_ax\n",
-    "from microsplit_reproducibility.notebook_utils.custom_dataset_3D import pick_random_patches_with_content\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "img_sz = 128\n",
-    "rand_locations = pick_random_patches_with_content(tar, 128)\n",
-    "h_start = rand_locations[2, 1] #np.random.randint(stitched_predictions.shape[1] - img_sz)\n",
-    "w_start = rand_locations[2, 2] #np.random.randint(stitched_predictions.shape[2] - img_sz)\n",
-    "\n",
-    "ncols = 2*NUM_CHANNELS + 1\n",
-    "nrows = min(len(rand_locations), 5)\n",
-    "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 3, nrows * 3))\n",
-    "\n",
-    "for i, (z_idx, h_start, w_start) in enumerate(rand_locations[:nrows]):\n",
-    "    ax[i, 0].imshow(inp[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz])\n",
-    "    for j in range(ncols//2):\n",
-    "        vmin = stitched_predictions[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j].min()\n",
-    "        vmax = stitched_predictions[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j].max()\n",
-    "        ax[i, 2*j+1].imshow(tar[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j], vmin=vmin, vmax=vmax)\n",
-    "        ax[i, 2*j+2].imshow(stitched_predictions[0, z_idx, h_start:h_start+img_sz, w_start:w_start+img_sz, j], vmin=vmin, vmax=vmax)\n",
-    "\n",
-    "ax[0,0].set_title('Primary Input')\n",
-    "for i in range(NUM_CHANNELS):\n",
-    "    ax[0, 2*i+1].set_title(f'Target Channel {i+1}')\n",
-    "    ax[0, 2*i+2].set_title(f'Predicted Channel {i+1}')\n",
-    "\n",
-    "# reduce the spacing between the subplots\n",
-    "plt.subplots_adjust(wspace=0.03, hspace=0.03)\n",
-    "clean_ax(ax)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## *Optional:* manual inspection of the predictions\n",
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b> Task:</b> Set <i>y_start</i>, <i>x_start</i>, and <i>crop_size</i> to inspect the predictions at a  location of your choice.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "y_start = 600  #np.random.randint(stitched_predictions.shape[1] - crop_size)\n",
-    "x_start = 1150 #np.random.randint(stitched_predictions.shape[2] - crop_size)\n",
-    "z_idx = 0\n",
-    "crop_size = 128\n",
-    "\n",
-    "ncols = NUM_CHANNELS + 1\n",
-    "nrows = 2\n",
-    "fig, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=(ncols * 5, nrows * 5))\n",
-    "ax[0,0].imshow(inp[0, z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size])\n",
-    "for i in range(ncols -1):\n",
-    "    vmin = stitched_predictions[0,z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i].min()\n",
-    "    vmax = stitched_predictions[0,z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i].max()\n",
-    "    ax[0,i+1].imshow(tar[0,z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i], vmin=vmin, vmax=vmax)\n",
-    "    ax[1,i+1].imshow(stitched_predictions[0, z_idx, y_start:y_start+crop_size, x_start:x_start+crop_size, i], vmin=vmin, vmax=vmax)\n",
-    "\n",
-    "# disable the axis for ax[1,0]\n",
-    "ax[1,0].axis('off')\n",
-    "ax[0,0].set_title(\"Input\")\n",
-    "ax[0,1].set_title(\"Channel 1\")\n",
-    "ax[0,2].set_title(\"Channel 2\")\n",
-    "# set y labels on the right for ax[0,2]\n",
-    "ax[0,2].yaxis.set_label_position(\"right\")\n",
-    "ax[0,2].set_ylabel(\"Target\")\n",
-    "\n",
-    "ax[1,2].yaxis.set_label_position(\"right\")\n",
-    "ax[1,2].set_ylabel(\"Predicted\")\n",
-    "\n",
-    "print('Here the crop you selected:')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# ***Optional Step 1.4:*** Posterior Sampling\n",
-    "For a given input patch, <nobr>Micro$\\mathbb{S}$plit</nobr> can generate multiple outputs. This is possible because <nobr>Micro$\\mathbb{S}$plit</nobr> is learning a full posterior of possible solutions, which is a quite powerful feature!\n",
-    "\n",
-    "As we elaborate in the <nobr>Micro$\\mathbb{S}$plit</nobr> paper and also later in the calibration notebook `03_calibration.ipynb`, this allows users to visually judge and even quantify the (data) uncertainty in the predictions their trained model makes.\n",
-    "\n",
-    "Below, we show two posterior samples and how much they differ for a few random foreground locations. Re-run the cell to see different randomly choosen locations and corresponding posterior samples."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from microsplit_reproducibility.notebook_utils.custom_dataset_3D import show_sampling\n",
-    "imgsz = 3\n",
-    "ncols = 6\n",
-    "examplecount = 3\n",
-    "_,ax = plt.subplots(figsize=(imgsz*ncols, imgsz*2*examplecount), ncols=ncols, nrows=2*examplecount)\n",
-    "\n",
-    "show_sampling(val_dset, model, ax=ax[:2])\n",
-    "show_sampling(val_dset, model, ax=ax[2:4])\n",
-    "show_sampling(val_dset, model, ax=ax[4:6])\n",
-    "plt.tight_layout()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### You are done here! 👍 Congratulations! 🎉"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "careamics",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.14"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 4
 }

--- a/src/microsplit_reproducibility/configs/factory.py
+++ b/src/microsplit_reproducibility/configs/factory.py
@@ -1,17 +1,21 @@
 from typing import Literal, Optional
 
+import torch
 from careamics.config import VAEBasedAlgorithm
 from careamics.config.architectures import LVAEModel
-from careamics.config.loss_model import LVAELossConfig, KLLossConfig
+from careamics.config.likelihood_model import (
+    GaussianLikelihoodConfig,
+    NMLikelihoodConfig,
+)
+from careamics.config.loss_model import KLLossConfig, LVAELossConfig
 from careamics.config.nm_model import GaussianMixtureNMConfig, MultiChannelNMConfig
-from careamics.config.likelihood_model import GaussianLikelihoodConfig, NMLikelihoodConfig
+from careamics.config.optimizer_models import LrSchedulerModel, OptimizerModel
 from careamics.config.training_model import TrainingConfig
-from careamics.config.optimizer_models import OptimizerModel, LrSchedulerModel
 
 
 def get_model_config(**kwargs) -> LVAEModel:
     """Get the model configuration for the MicroSplit model.
-    
+
     Parameters
     ----------
     ...
@@ -32,17 +36,17 @@ def get_model_config(**kwargs) -> LVAEModel:
         predict_logvar=kwargs["predict_logvar"],
         analytical_kl=False,
     )
-    
+
 
 def get_likelihood_config(
     **kwargs,
 ) -> tuple[GaussianLikelihoodConfig, MultiChannelNMConfig, NMLikelihoodConfig]:
     """Get the likelihood configuration for split models.
-    
+
     Parameters
     ----------
     ...
-    
+
     Returns
     -------
     tuple[GaussianLikelihoodConfig, MultiChannelNMConfig, NMLikelihoodConfig]
@@ -80,11 +84,11 @@ def get_likelihood_config(
 
 def get_loss_config(**kwargs) -> LVAELossConfig:
     """Get the loss configuration for the split model.
-    
+
     Parameters
     ----------
     ...
-    
+
     Returns
     -------
     LVAELossConfig
@@ -96,23 +100,32 @@ def get_loss_config(**kwargs) -> LVAELossConfig:
             loss_type=kwargs["kl_type"],
         ),
     )
-    
+
 
 def get_training_config(**kwargs) -> TrainingConfig:
     """Get the training configuration.
-    
+
     Parameters
     ----------
     ...
-    
+
     Returns
     -------
     TrainingConfig
         The training configuration.
     """
+    # AMP on non-CUDA backends can emit CUDA autocast warnings (e.g. on MPS),
+    # so default to mixed precision only when CUDA is available.
+    if kwargs.get("precision") is not None:
+        precision = kwargs["precision"]
+    elif torch.cuda.is_available():
+        precision = "16-mixed"
+    else:
+        precision = "32"
+
     return TrainingConfig(
         num_epochs=kwargs["num_epochs"],
-        precision="16-mixed",
+        precision=precision,
         logger="wandb",
         gradient_clip_algorithm="value",
         grad_clip_norm_value=0.5,
@@ -132,7 +145,7 @@ def get_lr_scheduler_config(**kwargs) -> LrSchedulerModel:
             "min_lr": 1e-12,
         },
     )
-    
+
 
 def get_optimizer_config(**kwargs) -> OptimizerModel:
     return OptimizerModel(
@@ -142,6 +155,7 @@ def get_optimizer_config(**kwargs) -> OptimizerModel:
             "weight_decay": 0,
         },
     )
+
 
 # TODO: Some of these are typed as optional but VAEBasedAlgorithm does not agree...
 def create_algorithm_config(
@@ -155,7 +169,7 @@ def create_algorithm_config(
     lr_scheduler_config: Optional[LrSchedulerModel] = None,
 ) -> VAEBasedAlgorithm:
     """Instantiate the split algorithm config.
-    
+
     Parameters
     ----------
     algorithm : Literal["muspit", "denoisplit"]
@@ -183,7 +197,7 @@ def create_algorithm_config(
     # TODO: VAEBasedAlgorithm in CAREamics needs to be updated so that
     #   - optimizer can be None
     #   - lr_schedular can be None
-    
+
     # this is so that we fall back on the defaults set in VAEBasedAlgorithm if any
     # of the optional params are passed as none
     vae_algorithm_params = {
@@ -196,14 +210,12 @@ def create_algorithm_config(
         "noise_model": nm_config,
         "noise_model_likelihood": nm_lik_config,
         "optimizer": optimizer_config,
-        "lr_scheduler": lr_scheduler_config
+        "lr_scheduler": lr_scheduler_config,
     }
     for key, value in optional_params.items():
-        # values which are None do not get added, 
+        # values which are None do not get added,
         # now defaults in VAEBasedAlgorithm will be used
         if value is not None:
             vae_algorithm_params[key] = value
-    
-    return VAEBasedAlgorithm(
-        **vae_algorithm_params
-    )
+
+    return VAEBasedAlgorithm(**vae_algorithm_params)

--- a/src/microsplit_reproducibility/datasets/HT_H23B.py
+++ b/src/microsplit_reproducibility/datasets/HT_H23B.py
@@ -552,9 +552,10 @@ class MultiChDloaderRef:
 
     def normalize_target(self, target):
         mean_dict, std_dict = self.get_mean_std()
-        mean_ = mean_dict["target"]  # .squeeze(0)
-        std_ = std_dict["target"]  # .squeeze(0)
-        return (target - mean_) / std_
+        mean_ = mean_dict["target"].astype(np.float32)  # .squeeze(0)
+        std_ = std_dict["target"].astype(np.float32)  # .squeeze(0)
+        target = target.astype(np.float32)
+        return ((target - mean_) / std_).astype(np.float32)
 
     def get_grid_size(self):
         return self._grid_sz

--- a/src/microsplit_reproducibility/notebook_utils/HT_H23B.py
+++ b/src/microsplit_reproducibility/notebook_utils/HT_H23B.py
@@ -7,6 +7,7 @@ from microsplit_reproducibility.datasets import (
     SplittingDataset,
 )
 from microsplit_reproducibility.datasets.HT_H23B import get_train_val_data
+from microsplit_reproducibility.utils.utils import cast_model_floats
 
 import os
 from pathlib import Path
@@ -25,6 +26,7 @@ def load_pretrained_model(model: VAEModule, ckpt_path):
         raise ValueError(
             "Checkpoint path must start with 'checkpoints' or 'pretrained_checkpoints'."
         )
+    cast_model_floats(model)
     print(f"Loaded model from {ckpt_path}")
 
 

--- a/src/microsplit_reproducibility/notebook_utils/HT_H24.py
+++ b/src/microsplit_reproducibility/notebook_utils/HT_H24.py
@@ -7,6 +7,7 @@ from microsplit_reproducibility.datasets import (
     SplittingDataset,
 )
 from microsplit_reproducibility.datasets.HT_LIF24 import get_train_val_data
+from microsplit_reproducibility.utils.utils import cast_model_floats
 
 import os
 from pathlib import Path
@@ -25,6 +26,7 @@ def load_pretrained_model(model: VAEModule, ckpt_path):
         raise ValueError(
             "Checkpoint path must start with 'checkpoints' or 'pretrained_checkpoints'."
         )
+    cast_model_floats(model)
     print(f"Loaded model from {ckpt_path}")
 
 

--- a/src/microsplit_reproducibility/notebook_utils/HT_LIF24.py
+++ b/src/microsplit_reproducibility/notebook_utils/HT_LIF24.py
@@ -7,6 +7,7 @@ from microsplit_reproducibility.datasets import (
     SplittingDataset,
 )
 from microsplit_reproducibility.datasets.HT_LIF24 import get_train_val_data
+from microsplit_reproducibility.utils.utils import cast_model_floats
 
 import os
 from pathlib import Path
@@ -65,6 +66,7 @@ def load_pretrained_model(model: VAEModule, ckpt_path):
         raise ValueError(
             "Checkpoint path must start with 'checkpoints' or 'pretrained_checkpoints'."
         )
+    cast_model_floats(model)
     print(f"Loaded model from {ckpt_path}")
 
 

--- a/src/microsplit_reproducibility/notebook_utils/custom_dataset_2D.py
+++ b/src/microsplit_reproducibility/notebook_utils/custom_dataset_2D.py
@@ -4,6 +4,7 @@ from careamics.lvae_training.eval_utils import get_predictions, get_device
 from careamics.lightning import VAEModule
 from microsplit_reproducibility.datasets import create_train_val_datasets, SplittingDataset
 from microsplit_reproducibility.datasets.HT_LIF24 import get_train_val_data
+from microsplit_reproducibility.utils.utils import cast_model_floats
 
 import os
 from pathlib import Path
@@ -18,6 +19,7 @@ def load_pretrained_model(model: VAEModule, ckpt_path):
     device = get_device()
     ckpt_dict = torch.load(ckpt_path, map_location=device, weights_only=True)
     model.load_state_dict(ckpt_dict['state_dict'], strict=False)
+    cast_model_floats(model)
     print(f"Loaded model from {ckpt_path}")
 
 

--- a/src/microsplit_reproducibility/notebook_utils/custom_dataset_3D.py
+++ b/src/microsplit_reproducibility/notebook_utils/custom_dataset_3D.py
@@ -4,6 +4,7 @@ from careamics.lvae_training.eval_utils import get_predictions, get_device
 from careamics.lightning import VAEModule
 from microsplit_reproducibility.datasets import create_train_val_datasets, SplittingDataset
 from microsplit_reproducibility.datasets.HT_LIF24 import get_train_val_data
+from microsplit_reproducibility.utils.utils import cast_model_floats
 
 import os
 from pathlib import Path
@@ -16,6 +17,7 @@ def load_pretrained_model(model: VAEModule, ckpt_path):
     device = get_device()
     ckpt_dict = torch.load(ckpt_path, map_location=device, weights_only=True)
     model.load_state_dict(ckpt_dict['state_dict'], strict=False)
+    cast_model_floats(model)
     print(f"Loaded model from {ckpt_path}")
 
 

--- a/src/microsplit_reproducibility/utils/utils.py
+++ b/src/microsplit_reproducibility/utils/utils.py
@@ -14,6 +14,29 @@ def fix_seeds(seed: int = 0) -> None:
     torch.backends.cudnn.deterministic = True
 
 
+def cast_model_floats(
+    model: torch.nn.Module, dtype: torch.dtype = torch.float32
+) -> torch.nn.Module:
+    """
+    Cast every floating parameter and buffer to the requested dtype.
+    """
+    model.to("cpu")
+    model.to(dtype=dtype)
+
+    incompatible_tensors = []
+    for name, tensor in list(model.named_parameters()) + list(model.named_buffers()):
+        if torch.is_floating_point(tensor) and tensor.dtype != dtype:
+            incompatible_tensors.append(f"{name}:{tensor.dtype}")
+
+    if incompatible_tensors:
+        preview = ", ".join(incompatible_tensors[:5])
+        raise TypeError(
+            f"Model still contains floating tensors that are not {dtype}: {preview}"
+        )
+
+    return model
+
+
 def get_ignored_pixels(pred: torch.Tensor) -> int:
     """Get the number of ignored pixels in the predictions.
 


### PR DESCRIPTION
## Disclaimer

- [ ] I am an AI agent.
- [x] I have used AI and I thoroughly reviewed every line.
- [ ] I have not used AI extensively.

## Description

> [!NOTE]  
> **tldr**: Fix MPS dtype/precision issues in train and predict flows by enforcing float32-safe paths and non-CUDA precision defaults.

### Background - why do we need this PR?

On Apple Silicon (`accelerator="mps"`), training/prediction failed with float64-related errors (e.g. MPS cannot run float64 tensors). We also saw CUDA autocast warnings despite running on MPS due to mixed precision defaults.

### Overview - what changed?

Added repo-local safeguards to keep model/data tensors float32-compatible and adjusted central training precision selection to avoid CUDA mixed-precision defaults on non-CUDA devices.

### Implementation - how did you implement the changes?

- Updated central training config precision selection:
  - CUDA: `16-mixed`
  - non-CUDA (MPS/CPU): `32`
  - explicit precision override still respected.
- Added a small notebook helper block in all training notebooks for manual MPS recovery.


### Modified features or files
- `src/microsplit_reproducibility/configs/factory.py`
- `examples/**/01_train.ipynb` (all training notebooks)

### Removed features or files
- None.

## How has this been tested?

- Reproduced prior failures from train/predict notebook flows.
- Verified touched Python files have no new linter errors.
- Manual notebook validation both on MPS and CUDA

## Related Issues

- Resolves #24 
